### PR TITLE
MonoDevelop 2.6b3 changes

### DIFF
--- a/src/FSharpInteractivePad.fs
+++ b/src/FSharpInteractivePad.fs
@@ -29,12 +29,9 @@ type FSharpInteractivePad() =
   let mutable enterHandler = { new IDisposable with member x.Dispose() = () }
 
   let AddSourceToSelection selection =
-     let line = ref 0
-     let col  = ref 0
-     let stap = IdeApp.Workbench.ActiveDocument.TextEditor.SelectionStartPosition
-     IdeApp.Workbench.ActiveDocument.TextEditor.GetLineColumnFromPosition(stap, line, col)
+     let line = IdeApp.Workbench.ActiveDocument.Editor.MainSelection.MinLine
      let file = IdeApp.Workbench.ActiveDocument.FileName
-     String.Format("# {0} \"{1}\"\n{2}" ,line.Value ,file.FullPath,selection)  
+     String.Format("# {0} \"{1}\"\n{2}", line, file.FullPath, selection)  
 
   let rec setupReleaseHandler (ea:Gtk.KeyReleaseEventArgs) =
     enterHandler.Dispose()
@@ -123,7 +120,7 @@ type FSharpInteractivePad() =
         
   member x.SendSelection() = 
     if x.IsSelectionNonEmpty then
-      let sel = IdeApp.Workbench.ActiveDocument.TextEditor.SelectedText
+      let sel = IdeApp.Workbench.ActiveDocument.Editor.SelectedText
       x.EnsureCorrectDirectory()
       sendCommand (AddSourceToSelection sel) false
       
@@ -131,8 +128,8 @@ type FSharpInteractivePad() =
     if IdeApp.Workbench.ActiveDocument = null then () 
     else
       x.EnsureCorrectDirectory()
-      let line = IdeApp.Workbench.ActiveDocument.TextEditor.CursorLine
-      let text = IdeApp.Workbench.ActiveDocument.TextEditor.GetLineText(line)
+      let line = IdeApp.Workbench.ActiveDocument.Editor.Caret.Line
+      let text = IdeApp.Workbench.ActiveDocument.Editor.GetLineText(line)
       let file = IdeApp.Workbench.ActiveDocument.FileName
       let sel = String.Format("# {0} \"{1}\"\n{2}" ,line ,file.FullPath,text) 
       sendCommand sel false
@@ -141,7 +138,7 @@ type FSharpInteractivePad() =
     if IdeApp.Workbench.ActiveDocument = null || 
        IdeApp.Workbench.ActiveDocument.FileName.FileName = null then false  
     else
-      let sel = IdeApp.Workbench.ActiveDocument.TextEditor.SelectedText
+      let sel = IdeApp.Workbench.ActiveDocument.Editor.SelectedText
       not(String.IsNullOrEmpty(sel))
     
   member x.IsInsideFSharpFile = 

--- a/src/FSharpLanguageBinding.fs
+++ b/src/FSharpLanguageBinding.fs
@@ -29,7 +29,7 @@ type FSharpLanguageBinding() =
       // Trigger full parse using the current configuration
       let config = IdeApp.Workspace.ActiveConfiguration
       Debug.tracef "Parsing" "Triggering full parse from OnIdle"
-      LanguageService.Service.TriggerParse(doc.FileName, doc.TextEditor.Text, doc.Dom, config, full=true)
+      LanguageService.Service.TriggerParse(doc.FileName, doc.Editor.Text, doc.Dom, config, full=true)
     true
 
   // Create or remove Idle timer 

--- a/src/FSharpParser.fs
+++ b/src/FSharpParser.fs
@@ -10,7 +10,7 @@ type FSharpParsedDocument(fileName) =
   inherit ParsedDocument(fileName)
   
 type FSharpParser() =
-  inherit AbstractParser("F#", "text/x-fsharp")
+  inherit AbstractParser()
   
   override x.CanParse(fileName) =
     Common.supportedExtension(IO.Path.GetExtension(fileName))

--- a/src/FSharpTextEditorCompletion.fs
+++ b/src/FSharpTextEditorCompletion.fs
@@ -54,7 +54,7 @@ type FSharpTextEditorCompletion() =
   override x.CodeCompletionCommand(context:CodeCompletionContext) : ICompletionDataList =
     try 
       let config = IdeApp.Workspace.ActiveConfiguration
-      let req = x.Document.FileName, x.Document.TextEditor.Text, x.Document.Dom, config
+      let req = x.Document.FileName, x.Document.Editor.Text, x.Document.Dom, config
       
       // Try to get typed information from LanguageService (with the specified timeout)
       let tyRes = LanguageService.Service.GetTypedParseResult(req, timeout = ServiceSettings.blockingTimeout)

--- a/src/Services/FSharpCompiler.fs
+++ b/src/Services/FSharpCompiler.fs
@@ -47,7 +47,7 @@ module Reflection =
         | [] -> failwithf "No method '%s' with %d arguments found" name args.Length
         | _::_::_ -> failwithf "Multiple methods '%s' with %d arguments found" name args.Length
         | [:? ConstructorInfo as c] -> c.Invoke(args)
-        | [ m ] -> m.Invoke(instance, args) ) |> unbox<'R>
+        | [ m ] -> m.Invoke(instance, BindingFlags.ExactBinding, null, args, System.Globalization.CultureInfo.InvariantCulture) ) |> unbox<'R>
     else
       // When the 'o' object is 'System.Type', we access static properties
       let typ, flags, instance = 

--- a/src/Services/LanguageService.fs
+++ b/src/Services/LanguageService.fs
@@ -163,22 +163,22 @@ type internal TypedParseResult(info:TypeCheckInfo) =
 
   /// Get declarations at the current location in the specified document
   /// (used to implement dot-completion in 'FSharpTextEditorCompletion.fs')
-  member x.GetDeclarations(doc:Document) = 
-    let lineStr = doc.TextEditor.GetLineText(doc.TextEditor.CursorLine)
+  member x.GetDeclarations(doc:MonoDevelop.Ide.Gui.Document) = 
+    let lineStr = doc.Editor.GetLineText(doc.Editor.Caret.Line)
     
     // Get the long identifier before the current location
     // 'residue' is the part after the last dot and 'longName' is before
     // e.g.  System.Console.Wri  --> "Wri", [ "System"; "Console"; ]
-    let lookBack = Parsing.createBackStringReader lineStr (doc.TextEditor.CursorColumn - 2)
+    let lookBack = Parsing.createBackStringReader lineStr (doc.Editor.Caret.Column - 2)
     let residue, longName = 
       lookBack 
       |> Parsing.getFirst Parsing.parseBackIdentWithResidue
     
     Debug.tracef "Result" "GetDeclarations: column: %d, ident: %A\n    Line: %s" 
-      (doc.TextEditor.CursorLine - 1) (longName, residue) lineStr
+      (doc.Editor.Caret.Line - 1) (longName, residue) lineStr
     let res = 
       info.GetDeclarations
-        ( (doc.TextEditor.CursorLine - 1, doc.TextEditor.CursorColumn - 1), 
+        ( (doc.Editor.Caret.Line - 1, doc.Editor.Caret.Column - 1), 
           lineStr, (longName, residue), 0) // 0 is tokenTag, which is ignored in this case
 
     Debug.tracef "Result" "GetDeclarations: returning %d items" res.Items.Length
@@ -412,7 +412,7 @@ type internal LanguageService private () =
     Debug.tracef "Errors" "Trigger update after completion"
     let doc = IdeApp.Workbench.ActiveDocument
     if doc.FileName.FullPath = file.FullPath then
-      ProjectDomService.Parse(file.ToString(), "text/x-fsharp", fun () -> doc.TextEditor.Text) |> ignore
+      ProjectDomService.Parse(file.ToString(), fun () -> doc.Editor.Text) |> ignore
     updatingErrors <- false
 
   // ------------------------------------------------------------------------------------


### PR DESCRIPTION
The least number of changes that I needed to make to get the F# plugin to compile against MonoDevelop 2.6b3.

Two issues:

(1) There's a memory leak somewhere, and I don't know where (or how) to find it.
(2) There seems to be a problem with Mono's dynamic-invocation; the change made to FSharpCompiler.fs is an unsuccessful workaround.  I'm open to any ideas on how to solve that issue more thoroughly…
