### PR TITLE
Compiler and path error fix

### DIFF
--- a/src/Services/Common.fs
+++ b/src/Services/Common.fs
@@ -319,8 +319,8 @@ module Common =
   /// Generates command line options for the compiler specified by the 
   /// F# compiler options (debugging, tail-calls etc.), custom command line
   /// parameters and assemblies referenced by the project ("-r" options)
-  let generateCompilerOptions (fsconfig:FSharpCompilerParameters) items config =
-    let dashr = generateReferences items config false |> Array.ofSeq
+  let generateCompilerOptions (fsconfig:FSharpCompilerParameters) items config shouldWrap =
+    let dashr = generateReferences items config shouldWrap |> Array.ofSeq
     let defines = fsconfig.DefinedSymbols.Split([| ';'; ','; ' ' |], StringSplitOptions.RemoveEmptyEntries)
     [| yield "--noframework"
        for symbol in defines do yield "--define:" + symbol

--- a/src/Services/CompilerService.fs
+++ b/src/Services/CompilerService.fs
@@ -37,7 +37,8 @@ module CompilerService =
 
     // Generate compiler options based on F# specific project settings
     let fsconfig = config.CompilationParameters :?> FSharpCompilerParameters
-    yield! Common.generateCompilerOptions fsconfig items configSel }
+    let shouldWrap = true// The compiler argument paths should always be wrapped, since some paths (ie. on Windows) may contain spaces.
+    yield! Common.generateCompilerOptions fsconfig items configSel shouldWrap }
 
 
   /// Process a single message emitted by the F# compiler

--- a/src/Services/LanguageService.fs
+++ b/src/Services/LanguageService.fs
@@ -562,7 +562,8 @@ type internal LanguageService private () =
         let fsconfig = projConfig.CompilationParameters :?> FSharpCompilerParameters
         
         // Order files using the configuration settings & get options
-        let args = Common.generateCompilerOptions fsconfig dom.Project.Items config
+        let shouldWrap = false //It is unknown if the IntelliSense fails to load assemblies with wrapped paths.
+        let args = Common.generateCompilerOptions fsconfig dom.Project.Items config shouldWrap
         let root = System.IO.Path.GetDirectoryName(dom.Project.FileName.FullPath.ToString())
         let files = Common.getItemsInOrder root files fsbuild.BuildOrder false |> Array.ofSeq
         CheckOptions.Create(projFile, files, args, false, false) 


### PR DESCRIPTION
The error has been observed while compiling on Windows 7.
Due to a path not wrapped in double quotes,
the compiling fails. This is likely due to spaces
occuring in the path. The fix ensures that paths
are wrapped in quotes when compiling.
Wrapping is not used in LanguageService.fs,
since the IntelliSense may fail to load assemblies
if it gets a wrapped path.
The fix has been tested on Debian Wheezy and Windows 7.
