### PR TITLE
Fixes a NullReferenceException when the binding was instantiated from mdtool

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
+++ b/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
@@ -17,19 +17,21 @@ type FSharpLanguageBinding() =
   let provider = lazy new CodeDom.FSharpCodeProvider()
   
   // ------------------------------------------------------------------------------------
-  // Watch for changes that trigger a reparse 
+  // Watch for changes that trigger a reparse, but only if we're running within the IDE context
+  // and not from mdtool or something like it.
 
-  // Register handler that will reparse when the active configuration is changes
-  do IdeApp.Workspace.ActiveConfigurationChanged.Add(fun _ -> 
-         for doc in IdeApp.Workbench.Documents do
-             if doc.Editor <> null then 
-                doc.ReparseDocument ())
+  do if IdeApp.IsInitialized then
+    // Register handler that will reparse when the active configuration is changes
+      IdeApp.Workspace.ActiveConfigurationChanged.Add(fun _ -> 
+             for doc in IdeApp.Workbench.Documents do
+                 if doc.Editor <> null then 
+                   doc.ReparseDocument ())
 
-  // Register handler that will reparse when F# file is opened/closed (is this even needed?)
-  do IdeApp.Workbench.ActiveDocumentChanged.Add(fun _ ->
-    let doc = IdeApp.Workbench.ActiveDocument
-    if doc <> null && (CompilerArguments.supportedExtension(IO.Path.GetExtension(doc.FileName.ToString()))) then
-         doc.ReparseDocument())
+      // Register handler that will reparse when F# file is opened/closed (is this even needed?)
+      IdeApp.Workbench.ActiveDocumentChanged.Add(fun _ ->
+        let doc = IdeApp.Workbench.ActiveDocument
+        if doc <> null && (CompilerArguments.supportedExtension(IO.Path.GetExtension(doc.FileName.ToString()))) then
+             doc.ReparseDocument())
 
     
   


### PR DESCRIPTION
When building from the command line, mdtool is sometimes used (ie. for projects that don't have MSBuild targets—examples include MonoTouch, MonoMac, etc.). In the case where the `FSharpLanguageBinding` was instantiated from this context, it would try to access `IdeApp.Workbench`, which is null (there is no workbench), causing a `NullReferenceException` and making mdtool not usable for builds.

This PR fixes that by wrapping references to `IdeApp.Workbench` in a check for `IdeApp.IsInitialized` which will be false if and only if the current context is mdtool or some similar non-UI tool. In the normal case, `IdeApp.IsInitialized` will be true and this won't be an issue.
