### PR TITLE
Missing override for virtual method

### DIFF
--- a/MonoDevelop.FSharpBinding/Services/Parameters.fs
+++ b/MonoDevelop.FSharpBinding/Services/Parameters.fs
@@ -56,6 +56,9 @@ type FSharpCompilerParameters() =
       x.DefineConstants <- null
     elif x.DefineConstants <> null then
       x.DefineConstants <- x.DefineConstants.Replace(";" + symbol, null)
+     
+  override x.HasDefineSymbol(symbol) =
+    x.DefineConstants.Split(';') |> Array.exists (fun s -> symbol = s)
 
   member x.DefineConstants 
     with get() = if x.defineConstants = null then "" else x.defineConstants


### PR DESCRIPTION
I had to add a missing override of a virtual method to build against the current HEAD of Monodevelop git.

I've submitted this pull request with a method implementation, but I must admit I'm not sure if this is the best way of handling it as it will break the build against earlier Monodevelop versions.
