### PR TITLE
Emacs package changes

### DIFF
--- a/emacs/fsharp-mode-pkg.el
+++ b/emacs/fsharp-mode-pkg.el
@@ -1,0 +1,1 @@
+(define-package "fsharp-mode" "0.3" "F# mode for Emacs")

--- a/emacs/fsharp.el
+++ b/emacs/fsharp.el
@@ -88,6 +88,10 @@
       (define-key map [eval-phrase] '("Eval phrase" . fsharp-eval-phrase))
       )))
 
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.fs[iylx]?$" . fsharp-mode))
+
 (defvar fsharp-mode-syntax-table nil
   "Syntax table in use in fsharp mode buffers.")
 (if fsharp-mode-syntax-table
@@ -145,6 +149,7 @@
 (defvar fsharp-mode-hook nil
   "Hook for fsharp-mode")
 
+;;;###autoload
 (defun fsharp-mode ()
   "Major mode for editing fsharp code.
 

--- a/emacs/inf-fsharp.el
+++ b/emacs/inf-fsharp.el
@@ -133,6 +133,7 @@ be sent from another buffer in fsharp mode.
 ;; patched to from original run-fsharp sharing code with
 ;;  fsharp-run-process-when-needed
 
+;;;###autoload
 (defun run-fsharp (&optional cmd)
   "Run an inferior fsharp process.
 Input and output via buffer `*inferior-fsharp*'."


### PR DESCRIPTION
With fsharp-mode-pkg.el it's possible to make the fsharp-mode in a proper emacs package

I wrote a recipe for MELPA

http://melpa.milkbox.net/

that lets people install it with a simple
M-x package-install fsharp-mode

if you'll accept this, I'll send the recipe to MELPA right away

(also: thanks to milkypostman himself, the package needs less configuration in the init.el)
