### PR TITLE
Renamed the emacs features from "fsharp" to "fsharp-mode"

### DIFF
--- a/emacs/fsharp-mode-font.el
+++ b/emacs/fsharp-mode-font.el
@@ -163,4 +163,4 @@
 
 (add-hook 'inferior-fsharp-mode-hooks 'inferior-fsharp-mode-font-hook)
 
-(provide 'fsharp-font)
+(provide 'fsharp-mode-font)

--- a/emacs/fsharp-mode-indent.el
+++ b/emacs/fsharp-mode-indent.el
@@ -1633,4 +1633,4 @@ This tells add-log.el how to find the current function/method/variable."
      (progn (goto-char (point-max)))))
   (end-of-line))
 
-(provide 'fsharp-indent)
+(provide 'fsharp-mode-indent)

--- a/emacs/fsharp-mode.el
+++ b/emacs/fsharp-mode.el
@@ -20,7 +20,7 @@
 
 ;;user customizable variables
 
-(defvar fsharp-version 0.3
+(defvar fsharp-mode-version 0.3
   "Version of this fsharp-mode")
 
 (defvar inferior-fsharp-program "fsi"
@@ -156,8 +156,8 @@
 \\{fsharp-mode-map}"
   (interactive)
 
-  (require 'fsharp-indent)
-  (require 'fsharp-font)
+  (require 'fsharp-mode-indent)
+  (require 'fsharp-mode-font)
   (kill-all-local-variables)
   (use-local-map fsharp-mode-map)
   (set-syntax-table fsharp-mode-syntax-table)
@@ -266,13 +266,13 @@
 (defun fsharp-eval-region (start end)
   "Send the current region to the inferior fsharp process."
   (interactive"r")
-  (require 'inf-fsharp)
+  (require 'inf-fsharp-mode)
   (inferior-fsharp-eval-region start end))
 
 
 (defun fsharp-show-subshell ()
   (interactive)
-  (require 'inf-fsharp)
+  (require 'inf-fsharp-mode)
   (inferior-fsharp-show-subshell))
 
 
@@ -320,10 +320,10 @@ whole string."
     (if (string-match "^\\(.*\\)\\.\\(fs\\|fsi\\)$" name)
         (shell-command (concat (match-string 1 name) ".exe")))))
 
-(defun fsharp-version ()
+(defun fsharp-mode-version ()
   "Echo the current version of `fsharp-mode' in the minibuffer."
   (interactive)
-  (message "Using `fsharp-mode' version %s" fsharp-version)
+  (message "Using `fsharp-mode' version %s" fsharp-mode-version)
   (fsharp-keep-region-active))
 
-(provide 'fsharp)
+(provide 'fsharp-mode)

--- a/emacs/inf-fsharp-mode.el
+++ b/emacs/inf-fsharp-mode.el
@@ -1,6 +1,6 @@
 ;(***********************************************************************)
 ;(*                                                                     *)
-;(*                           Objective fsharp                            *)
+;(*                                F#                                   *)
 ;(*                                                                     *)
 ;(*                   Xavier Leroy and Jacques Garrigue                 *)
 ;(*                                                                     *)
@@ -21,7 +21,7 @@
 ;; modified by Laurent Le Brun for F#, 2010
 
 (require 'comint)
-(require 'fsharp)
+(require 'fsharp-mode)
 
 ;; User modifiable variables
 
@@ -370,4 +370,4 @@ should lies."
   (let ((comint-input-sender 'fsharp-simple-send))
     (comint-send-input)))
 
-(provide 'inf-fsharp)
+(provide 'inf-fsharp-mode)


### PR DESCRIPTION
This is the recipe pull request for melpa where they brought up this issue:
https://github.com/milkypostman/melpa/pull/413

Before making this pull request, I tested locally, and it should apply fine even after applying the other pull request https://github.com/fsharp/fsharpbinding/pull/71 (so, I'd suggest to apply 71 and 72 in order)

In the meanwhile, I realized that indeed the code is a bit brittle: hard and soft tabs mixed, commented out code, references to the ocaml mode, and even some evidence of some sed substitutions

like line 13 in inf-fsharp-mode.el:

the 2004 commit was almost surely on the ocaml codebase

some of these things probably derive from the fact that they've been manually managed/imported, and so they don't have an unique version control history (and at the time they were also probably using an old vcs program for which it was common practice to litter the source code with those comments)

I don't know how it could be handled this... maybe we could delete those spurious comments and add an AUTHORS file for those people who modified the sources and yet they don't pop up in the git log?

(I also tried to import and merge the history from sourceforge, but I don't deem it important enough: they're only 6 commits or so... and while merging there are some whole-file conflicts due to the change of newlines and such things)
