### PR TITLE
Use Ctrl-Return for Send-to-Interactive on Mac 

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -188,7 +188,7 @@
 					_label = "Send selection to F# Interactive"
 					_description="Send the selected text to F# Interactive"
 					shortcut="Ctrl|Return"
-					macShortcut="Alt|Return"
+					macShortcut="Ctrl|Return"
 					defaultHandler="MonoDevelop.FSharp.SendSelection" />
 
 			 <Command id="MonoDevelop.FSharp.FSharpCommands.SendLine"


### PR DESCRIPTION
For some reason "Alt-Return" stopped working for "Send to Interactive" in XamarinStudio. Perhaps the keystroke is reserved.

Just switch to use Ctrl-Return instead, which is what is used by Try F#.
