### PR TITLE
Exception thrown on tooltips in XamarinStudio(4.0)

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -157,7 +157,9 @@ module internal TipFormatter =
   let tryGetDoc key = 
     let helpTree = MonoDevelop.Projects.HelpService.HelpTree
     if helpTree = null then None 
-    else try Some(helpTree.GetHelpXml(key)) 
+    else try 
+            let helpxml = helpTree.GetHelpXml(key)
+            if helpxml = null then None else Some(helpxml)
          with ex -> Debug.WriteLine (sprintf "GetHelpXml failed for key %s:\r\n\t%A" key ex)
                     None  
                   


### PR DESCRIPTION
Was getting a NullReferenceException(below) when tooltips had no summary, originating from tryGetDoc returning Some(null)

```
Result: GetDeclarations: returning 35 items
key= "P:System.String.Chars(System.Int32)", File= "/usr/local/Cellar/mono3/3.0.3/lib/mono/4.0/mscorlib.dll"
SimpleKey parentId= System.String.Chars(System, name= Int32)
ERROR [2013-03-02 17:46:06Z]: An unhandled exception has occured. Terminating MonoDevelop? False
System.NullReferenceException: Object reference not set to an instance of an object
at MonoDevelop.FSharp.TipFormatter.findMonoDocProviderForEntity[String] (System.String file, System.String key) [0x00000] in <filename unknown>:0
  at MonoDevelop.FSharp.TipFormatter.findDocForEntity (System.String file, System.String key) [0x00000] in <filename unknown>:0
  at MonoDevelop.FSharp.TipFormatter.buildFormatComment (Microsoft.FSharp.Compiler.XmlComment cmt) [0x00000] in <filename unknown>:0
  at MonoDevelop.FSharp.TipFormatter.buildFormatElement (Boolean canAddHeader, Microsoft.FSharp.Compiler.DataTipElement el, System.Text.StringBuilder sb) [0x00000] in <filename unknown>:0
  at MonoDevelop.FSharp.TipFormatter.buildFormatTip (Boolean canAddHeader, Microsoft.FSharp.Compiler.DataTipText tip, System.Text.StringBuilder sb) [0x00000] in <filename unknown>:0
```
