### PR TITLE
F# emacs improvements

### DIFF
--- a/FSharp.AutoComplete/ProjectParser.fs
+++ b/FSharp.AutoComplete/ProjectParser.fs
@@ -54,12 +54,18 @@ module ProjectParser =
     let getprop s = p.project.GetEvaluatedProperty s
     let split (s: string) (cs: char[]) =
       s.Split(cs, StringSplitOptions.RemoveEmptyEntries)
-    // TODO: Robustify - convert.ToBoolean may fail
-    let optimize     = getprop "Optimize" |> Convert.ToBoolean
-    let tailcalls    = getprop "Tailcalls" |> Convert.ToBoolean
-    let debugsymbols = getprop "DebugSymbols" |> Convert.ToBoolean
+    let getbool (s: string) =
+      match (Boolean.TryParse s) with
+      | (true, result) -> result
+      | (false, _) -> false
+    let optimize     = getprop "Optimize" |> getbool
+    let tailcalls    = getprop "Tailcalls" |> getbool
+    let debugsymbols = getprop "DebugSymbols" |> getbool
     let defines = split (getprop "DefineConstants") [|';';',';' '|]
-    let otherflags = getprop "OtherFlags"
+    let otherflags = getprop "OtherFlags" 
+    // TODO: Robustify - convert.ToBoolean may fail
+//    
+
     let otherflags = if otherflags  = null
                      then [||]
                      else split otherflags [|' '|]

--- a/configure.sh
+++ b/configure.sh
@@ -29,7 +29,7 @@ elif test "x$PKG_CONFIG" = "xno"; then
     PKG_CONFIG=`which pkg-config`
 fi
 
-MONODIR=`$PKG_CONFIG --variable=libdir mono`/mono/4.0
+MONODIR=/usr/lib/mono/4.0
 
 echo "Assuming Mono root directory." $MONODIR
 

--- a/emacs/Makefile
+++ b/emacs/Makefile
@@ -45,7 +45,7 @@ install : $(ac_exe) $(dest_root) $(dest_bin)
 		cp $$f $(dest_root) ;\
 	done
 # Copy bin folder.
-	cp -R $(bin_d) $(dest_root)/bin
+	cp -R $(bin_d) $(dest_root)
 
 
 $(dest_root) :; mkdir -p $(dest_root)


### PR DESCRIPTION
More robust project parsing and fixed the copying of the emacs/bin folder to $HOME/.emacs.d/fsharp-mode/bin/ [the emacs/bin was being copied to $HOME/.emacs.d/fsharp-mode/bin/bin before].

Thanks
