### PR TITLE
Fix #146: Avoid creating extra FSI sessions on reset

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/InteractiveSession.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/InteractiveSession.fs
@@ -88,7 +88,7 @@ type InteractiveSession() =
   member x.SendCommand(str:string) = 
     waitingForResponse <- true
     Debug.WriteLine (sprintf "Interactive: sending %s" str)
-    fsiProcess.StandardInput.Write(str + ";;\n")
+    fsiProcess.StandardInput.Write(str + if str.EndsWith(";;") then "\n" else ";;\n")
 
   member x.Exited = fsiProcess.Exited
     


### PR DESCRIPTION
Issue #146: Because of bad eventing, on fsi reset, a new fsi session would be created only to be tossed immediately. This would also show itself in the ui. Now just one new session is created.

Also changed reset behaviour to be more like that of VS: Pressing reset button now clears the screen and does not wait for enter. `#q`or `#quit` or failure will wait for enter and not clear the screen.
