### PR TITLE
Sending code that ended with a comment to fsi did not yield results.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
@@ -110,7 +110,7 @@ type FSharpInteractivePad() =
      let stap = IdeApp.Workbench.ActiveDocument.Editor.SelectionRange.Offset
      let line = IdeApp.Workbench.ActiveDocument.Editor.OffsetToLineNumber(stap)
      let file = IdeApp.Workbench.ActiveDocument.FileName
-     String.Format("# {0} \"{1}\"\n{2}" ,line,file.FullPath,selection)  
+     String.Format("# {0} \"{1}\"\n{2}\n" ,line,file.FullPath,selection)  
 
   let ensureCorrectDirectory _ =
     getCorrectDirectory()
@@ -221,7 +221,7 @@ type FSharpInteractivePad() =
       let line = IdeApp.Workbench.ActiveDocument.Editor.Caret.Line
       let text = IdeApp.Workbench.ActiveDocument.Editor.GetLineText(line)
       let file = IdeApp.Workbench.ActiveDocument.FileName
-      let sel = String.Format("# {0} \"{1}\"\n{2}" ,line ,file.FullPath,text) 
+      let sel = String.Format("# {0} \"{1}\"\n{2}\n" ,line ,file.FullPath,text) 
       sendCommand sel
 
   member x.IsSelectionNonEmpty = 


### PR DESCRIPTION
Fixes #169. 
Just added a newline when sending.
