### PR TITLE
Removed version specific information for Mono.Addins reference

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.orig
@@ -141,7 +141,7 @@
     <Reference Include="System.Xaml" />
     <Reference Include="mscorlib" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="Mono.Addins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+    <Reference Include="Mono.Addins">
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.TextEditor">


### PR DESCRIPTION
Recent changes in the latest alpha of Xamarin introduced a dependency
on version 1.0.0.0.  Its really a version neutral file so there is no
need to bind to a specific version as the F# binding will be deployed
with a dependency on a specific version of MonoDevelop/Xamarin Studio.
