### PR TITLE
Implement more robust parsing of "raw" idents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ pack/*
 lib/NUnit.*
 lib/FsUnit.*
 
+FSharp.AutoComplete/test/integration/RawIdTest/FSharp.Data
+
 # Emacs
 *.elc
 emacs/deps

--- a/FSharp.AutoComplete/Program.fs
+++ b/FSharp.AutoComplete/Program.fs
@@ -224,8 +224,11 @@ type internal IntelliSenseAgent() =
       // 'residue' is the part after the last dot and 'longName' is before
       // e.g.  System.Console.Wri  --> "Wri", [ "System"; "Console"; ]
       let lookBack = Parsing.createBackStringReader lineStr (column - 1)
+      let results = Parser.apply Parsing.parseBackIdentWithEitherResidue lookBack
       let residue, longName =
-        lookBack |> Parsing.getFirst Parsing.parseBackIdentWithResidue
+        List.sortBy (fun (s,ss) -> String.length s + (List.sumBy String.length ss)) results
+        |> List.rev
+        |> List.head
 
       // Get items & generate output
       try

--- a/FSharp.AutoComplete/test/integration/RawIdTest/Runner.fsx
+++ b/FSharp.AutoComplete/test/integration/RawIdTest/Runner.fsx
@@ -1,0 +1,25 @@
+#load "../TestHelpers.fsx"
+open TestHelpers
+open System.IO
+open System
+
+(*
+ * This test is a simple sanity check of a basic run of the program.
+ * A few completions, files and script.
+ *)
+
+Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
+File.Delete "output.txt"
+
+if not (File.Exists "FSharp.Data/lib/net40/FSharp.Data.dll") then
+  installNuGetPkg "FSharp.Data"
+
+let p = new FSharpAutoCompleteWrapper()
+
+p.parse "Test.fsx"
+p.completion "Test.fsx" 5 19
+p.completion "Test.fsx" 7 32
+p.send "quit\n"
+let output = p.finalOutput ()
+File.WriteAllText("output.txt", output)
+

--- a/FSharp.AutoComplete/test/integration/RawIdTest/Test.fsx
+++ b/FSharp.AutoComplete/test/integration/RawIdTest/Test.fsx
@@ -1,0 +1,8 @@
+#I "FSharp.Data/lib/net40/"
+#r "FSharp.Data.dll"
+
+let data = FSharp.Data.FreebaseData.GetDataContext()
+
+data.``Arts and Ent
+
+data.``Arts and Entertainment``.

--- a/FSharp.AutoComplete/test/integration/RawIdTest/output.txt
+++ b/FSharp.AutoComplete/test/integration/RawIdTest/output.txt
@@ -1,0 +1,36 @@
+INFO: Background parsing started
+<<EOF>>
+DATA: completion
+Afval.nl
+Arts and Entertainment
+Commons
+DataContext
+Products and Services
+Science and Technology
+Society
+Special Interests
+Sports
+System
+Time and Space
+Transportation
+Waste
+afval
+afvalnl
+<<EOF>>
+DATA: completion
+Books
+Broadcast
+Comics
+Fictional Universes
+Film
+Games
+Media
+Music
+Opera
+Periodicals
+Radio
+TV
+Theater
+Video Games
+Visual Art
+<<EOF>>

--- a/FSharp.AutoComplete/test/integration/TestHelpers.fsx
+++ b/FSharp.AutoComplete/test/integration/TestHelpers.fsx
@@ -43,3 +43,15 @@ type FSharpAutoCompleteWrapper() =
     let t = p.StandardError.ReadToEnd()
     p.WaitForExit()
     s + t
+
+let installNuGetPkg s =
+  let p = new System.Diagnostics.Process()
+
+  p.StartInfo.FileName  <- "mono"
+  p.StartInfo.Arguments <-
+      IO.Path.Combine(__SOURCE_DIRECTORY__,
+                      "../../../lib/nuget/NuGet.exe")
+      + " install -ExcludeVersion "
+      + s
+  p.Start () |> ignore
+  

--- a/emacs/test/fsharp-mode-completion-tests.el
+++ b/emacs/test/fsharp-mode-completion-tests.el
@@ -199,3 +199,19 @@ function bound to VAR in BODY. "
     (fsharp-ac/show-typesig-at-point)
     (fsharp-ac-filter-output nil tooltip-msg)
     (should= "foo" sig)))
+
+;;; Residue computation
+
+(defmacro check-residue (desc line res)
+  `(check ,desc
+     (with-temp-buffer
+       (insert ,line)
+       (should= ,res (buffer-substring-no-properties (fsharp-ac--residue) (buffer-end 1))))))
+
+(check-residue "standard residue" "System.Console.WriteL" "WriteL")
+(check-residue "standard residue, previous raw identifier" "System.``Hello Console``.WriteL" "WriteL")
+(check-residue "raw residue, standard previous" "System.Console.``Writ eL" "``Writ eL")
+(check-residue "raw residue, raw previous" "System.``Hello Console``.``Wr$ it.eL" "``Wr$ it.eL")
+(check-residue "raw residue, trailing dot" "System.Console.``WriteL." "``WriteL.")
+
+


### PR DESCRIPTION
Without using the actual lexer to provide token information,
the best we can do is to try the current line (or potentially more)
assuming either that it ends in a raw residue or a normal one. We
then take the longest. The emacs code also follows this strategy
and it all seems to work well.

New tests are added that use FSharp.Data, fetching from NuGet if
required, to test against the original reported bugs.
