### PR TITLE
Don't offer completions after just a '.'

### DIFF
--- a/FSharp.AutoComplete/Program.fs
+++ b/FSharp.AutoComplete/Program.fs
@@ -218,15 +218,14 @@ type internal IntelliSenseAgent() =
   /// and current residue.
   member x.DoCompletion(opts : RequestOptions, ((line, column) as pos), lineStr, time) : Option<DeclarationSet * String> =
     let info = x.GetTypeCheckInfo(opts, time)
-    Option.bind (fun (info: TypeCheckResults) ->
-      let longName, residue = Parsing.findLongIdentsAndResidue (column, lineStr)
-
-      // Get items & generate output
+    Option.bind (fun (longName, residue) ->
+      Option.bind (fun (info: TypeCheckResults) ->
       try
         Some (info.GetDeclarations(None, pos, lineStr, (longName, residue), fun (_,_) -> false)
               |> Async.RunSynchronously, residue)
       with :? System.TimeoutException as e ->
                  None) info
+      ) (Parsing.findLongIdentsAndResidue (column, lineStr))
 
   /// Gets ToolTip for the specified location (and prints it to the output)
   member x.GetToolTip(opts, ((line, column) as pos), lineStr, time) : Option<DataTipText> =

--- a/FSharp.CompilerBinding/Parser.fs
+++ b/FSharp.CompilerBinding/Parser.fs
@@ -324,4 +324,12 @@ module Parsing =
         |> List.rev
         |> List.head
 
-    (longName, residue)
+    if String.IsNullOrEmpty residue &&
+       List.isEmpty longName &&
+       col >= 0 && col <= lineStr.Length &&
+       lineStr.[col - 1] = '.'
+    then
+        None
+    else
+        Some (longName, residue)
+


### PR DESCRIPTION
If there is no other ident information, then there can be no completions
