### PR TITLE
Fix FSharp.Core resolution issue in the MonoDevelop add-in

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -55,10 +55,10 @@ module CompilerArguments =
       match coreRef with
       | None ->
         let fullName = project.AssemblyContext.GetAssemblyFullName (assumedFile, project.TargetFramework);
-        let fxCoreRef = Some(project.AssemblyContext.GetAssemblyLocation(fullName, project.TargetFramework))
-        match fxCoreRef with
-        | Some fn -> yield "-r:" + wrapf(fn)
-        | None ->
+        let fxCoreRef = project.AssemblyContext.GetAssemblyLocation(fullName, project.TargetFramework)
+        if fxCoreRef <> null then
+          yield "-r:" + wrapf(fxCoreRef)
+        else
           let dirs = FSharpEnvironment.getDefaultDirectories(langVersion, targetFramework) 
           match FSharpEnvironment.resolveAssembly dirs assumedFile with
           | Some fn -> yield "-r:" + wrapf(fn)


### PR DESCRIPTION
The add-in has to resolve mscorlib and FSharp.Core using the project assembly context.
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=16731.
