### PR TITLE
Minor improvements to Language service

### DIFF
--- a/FSharp.CompilerBinding/LanguageService.fs
+++ b/FSharp.CompilerBinding/LanguageService.fs
@@ -48,8 +48,17 @@ type TypedParseResult(info:CheckFileResults, untyped : ParseFileResults) =
             let res = info.GetMethods(line, col, lineStr, Some identIsland)
             Debug.WriteLine("Result: Got something, returning")
             Some (res.MethodName, res.Methods) 
-            
-    member x.Untyped with get() = untyped 
+
+    member x.GetSymbol(line, col, lineStr) =
+        match Parsing.findLongIdents(col, lineStr) with 
+        | Some(colu, identIsland) ->
+            //get symbol at location
+            //Note we advance the caret to 'colu' ** due to GetSymbolAtLocation only working at the beginning/end **
+            info.GetSymbolAtLocation(line, colu, lineStr, identIsland)
+        | None -> None
+
+    member x.CheckFileResults with get() = info        
+    member x.ParseFileResults with get() = untyped 
 
 // --------------------------------------------------------------------------------------
 /// Represents request send to the background worker

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -408,7 +408,7 @@ type FSharpPathExtension() =
 
             let toplevel = 
                 // GetNavigationItems is not 100% solid and throws occasional exceptions
-                try ast.Untyped.GetNavigationItemsDeclarationsSafe()
+                try ast.ParseFileResults.GetNavigationItemsDeclarationsSafe()
                 with _ -> [| |] 
 
             let topLevelTypesInsideCursor =
@@ -472,12 +472,12 @@ and FSharpDataProvider(ext:FSharpPathExtension, tag) =
         memberList.Clear()
         match tag with
         | :? TypedParseResult as tpr ->
-            let navitems = tpr.Untyped.GetNavigationItemsDeclarationsSafe()
+            let navitems = tpr.ParseFileResults.GetNavigationItemsDeclarationsSafe()
             for decl in navitems do
                 memberList.Add(decl.Declaration)
         | :? (TypedParseResult * string) as typeAndFilter ->
             let tpr, filter = typeAndFilter 
-            let navitems = tpr.Untyped.GetNavigationItemsDeclarationsSafe()
+            let navitems = tpr.ParseFileResults.GetNavigationItemsDeclarationsSafe()
             for decl in navitems do
                 if decl.Declaration.Name.StartsWith(filter) then
                     memberList.Add(decl.Declaration)


### PR DESCRIPTION
Refactored naming of untyped parse info to match new naming in
FSharp.Compiler.Service.  Also exposed underlying CheckFileResult
