### PR TITLE
Added folding regions using navigation information and refactored Parsing.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpParser.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpParser.fs
@@ -19,12 +19,19 @@ type FSharpParser() =
   inherit TypeSystemParser()
   do Debug.WriteLine("Parsing: Creating FSharpParser")
         
-  /// Format errors for the given line (if there are multiple, we collapse them into a single one)
+  /// Holds the previous errors reported by a file. 
+  let activeResults = System.Collections.Generic.Dictionary<string,Error list>()
+
+  /// Holds the previous content used to generate the previous errors. An entry is only present if we have 
+  /// scheduled a new ReparseDocument() to update the errors.
+  let activeRequests = System.Collections.Generic.Dictionary<string,string>()
+  let mutable typedParsedResult = Unchecked.defaultof<_>
+
+    /// Format errors for the given line (if there are multiple, we collapse them into a single one)
   let formatError (error:ErrorInfo) =
       // Single error for this line
-      let typ = if error.Severity = Severity.Error then ErrorType.Error
-                else ErrorType.Warning
-      Error(typ, error.Message, DomRegion(error.StartLine + 1, error.StartColumn + 1, error.EndLine + 1, error.EndColumn + 1))
+      let typ = if error.Severity = Severity.Error then ErrorType.Error else ErrorType.Warning
+      new Error(typ, error.Message, DomRegion(error.StartLine + 1, error.StartColumn + 1, error.EndLine + 1, error.EndColumn + 1))
   
   /// To be called from the language service mailbox processor (on a 
   /// GUI thread!) when new errors are reported for the specified file
@@ -33,7 +40,7 @@ type FSharpParser() =
           yield formatError error ]
 
   override x.Parse(storeAst:bool, fileName:string, content:System.IO.TextReader, proj:MonoDevelop.Projects.Project) =
-    if fileName = null || proj = null || not (CompilerArguments.supportedExtension(Path.GetExtension(fileName))) then null else
+    if fileName = null || proj = null ||  not (CompilerArguments.supportedExtension(Path.GetExtension(fileName))) then null else
 
     let fileContent = content.ReadToEnd()
 
@@ -41,47 +48,61 @@ type FSharpParser() =
 
     let doc = new FSharpParsedDocument(fileName)
     doc.Flags <- doc.Flags ||| ParsedDocumentFlags.NonSerializable
-       
-    Debug.WriteLine("[Thread {0}]: TriggerParse file {1}, hash {2}", System.Threading.Thread.CurrentThread.ManagedThreadId, fileName, hash fileContent)
-    // Trigger a parse/typecheck in the background. After the parse/typecheck is completed, request another parse to report the errors.
-    //
-    // Trigger parsing in the language service 
-    let filePathOpt = 
-        // TriggerParse will work only for full paths
-        if IO.Path.IsPathRooted(fileName) then 
-            Some(fileName)
-        else 
-           let doc = IdeApp.Workbench.ActiveDocument 
-           if doc <> null then 
-               let file = doc.FileName.ToString()
-               if file = "" then None else Some file
-           else None
-    
-    let callTriggerParseAndWaitForResults(fileName, filePath, fileContent, files, args, framework) =
-        use wh = new Threading.ManualResetEvent(false)
-        let errs = ref Array.empty
-        MDLanguageService.Instance.TriggerParse(fileName, filePath, fileContent, files, args, framework,
-            (fun (_,errors) -> errs := errors
-                               wh.Set() |> ignore ))
-        wh.WaitOne(400) |> ignore
-        !errs
-                 
-    match filePathOpt with 
-    | None -> doc :> _
-    | Some filePath -> 
-      let config = IdeApp.Workspace.ActiveConfiguration
-      if config = null then doc :> _ else 
-        let files = CompilerArguments.getSourceFiles(proj.Items) |> Array.ofList
-        let args = CompilerArguments.getArgumentsFromProject(proj, config)
-        let framework = CompilerArguments.getTargetFramework( (proj :?> MonoDevelop.Projects.DotNetProject).TargetFramework.Id)
+
+    // Check if this is a reparse.
+    match activeRequests.TryGetValue(fileName) with 
+    | true, content when content = fileContent ->
+        activeRequests.Remove(fileName) |> ignore
+
+    | _ ->
   
-        let errors = callTriggerParseAndWaitForResults(proj.FileName.ToString(), filePath, fileContent, files, args, framework)
-        //add the errors to the doc
-        for er in makeErrors errors do
-            doc.Errors.Add(er) 
-  
-        let typedParsedResult = MDLanguageService.Instance.GetTypedParseResult(proj.FileName.ToString(), filePath, fileContent, files, args, true, 400, framework)
-  
+      Debug.WriteLine("[Thread {0}]: TriggerParse file {1}, hash {2}", System.Threading.Thread.CurrentThread.ManagedThreadId, fileName, hash fileContent)
+      // Trigger a parse/typecheck in the background. After the parse/typecheck is completed, request another parse to report the errors.
+      //
+      // Trigger parsing in the language service 
+      let filePathOpt = 
+          // TriggerParse will work only for full paths
+          if IO.Path.IsPathRooted(fileName) then 
+              Some(fileName)
+          else 
+             let doc = IdeApp.Workbench.ActiveDocument 
+             if doc <> null then 
+                 let file = doc.FileName.ToString()
+                 if file = "" then None else Some file
+             else None
+
+      match filePathOpt with 
+      | None -> ()
+      | Some filePath -> 
+        let config = IdeApp.Workspace.ActiveConfiguration
+        if config <> null then 
+          // Keep a record that we have an inflight check of this going on
+          activeRequests.[fileName] <- fileContent
+          let files = CompilerArguments.getSourceFiles(proj.Items) |> Array.ofList
+          let args = CompilerArguments.getArgumentsFromProject(proj, config)
+          let framework = CompilerArguments.getTargetFramework( (proj :?> MonoDevelop.Projects.DotNetProject).TargetFramework.Id)
+
+          MDLanguageService.Instance.TriggerParse(proj.FileName.ToString(), filePath, fileContent, files, args, framework,
+            (fun (_,errors) ->
+                DispatchService.GuiDispatch( fun () ->
+                    Debug.WriteLine("[Thread {0}]: Callback after parsing, file {1}, hash {2}", System.Threading.Thread.CurrentThread.ManagedThreadId, fileName, hash fileContent)
+
+                    // Keep the result until we reparse
+                    activeResults.[fileName] <- makeErrors errors
+                    typedParsedResult <- MDLanguageService.Instance.GetTypedParseResult(proj.FileName.ToString(), filePath, fileContent, files, args, true, 400, framework)
+                    // Schedule a reparse to actually update the errors, checking first if this is still the active document
+                    try 
+                       let doc = IdeApp.Workbench.ActiveDocument
+                       if doc <> null && doc.FileName.FullPath.ToString() = fileName then 
+                           Debug.WriteLine("[Thread {0}]: Parsing: Requesting re-parse of file {1}, hash {2}",System.Threading.Thread.CurrentThread.ManagedThreadId,fileName, hash fileContent)
+                           doc.ReparseDocument()
+                    with _ -> ())))
+
+    if activeResults.ContainsKey(fileName) then
+        for er in activeResults.[fileName] do 
+            doc.Errors.Add(er)  
+
+        //Set code folding regions
         //GetNavigationItems may throw in some situations
         try
           let regions =
@@ -94,11 +115,10 @@ type FSharpParser() =
                   for next in toplevel.Nested do yield processDecl next}
           doc.Add(regions)
         with _ -> Debug.Assert(false, "couldn't update navigation items, ignoring")  
-  
+        
+        //also store the AST of active results if applicable                
         if storeAst then
             doc.Ast <- typedParsedResult
-        //update the write time as we have updated the AST
-        doc.LastWriteTimeUtc <- try File.GetLastWriteTimeUtc fileName
-                                with _ -> DateTime.UtcNow    
-
-        doc :> ParsedDocument
+    
+    doc.LastWriteTimeUtc <- (try File.GetLastWriteTimeUtc (fileName) with _ -> DateTime.UtcNow) 
+    doc :> ParsedDocument


### PR DESCRIPTION
Also refactored the use of TriggerParse.  The parsing of source files
is already done on a queue using Tasks<T> in Xamarin studio, so we just
need to get the errors returned from the language service as soon as we
can rather than relying on the agent calling itself to get the results.
 This also avoids using a separate thread UI thread to add the
errors/warnings which is not necessary. Parsing is not required to
operate on the UI thread.  Another side effect is the code is simpler
to follow and slightly faster to return the first results.
