### PR TITLE
Make solution file compatible with VS 2010

### DIFF
--- a/FSharp.AutoComplete.sln
+++ b/FSharp.AutoComplete.sln
@@ -1,5 +1,5 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 10.00
 # Visual Studio 2012
 Project("{4925A630-B079-445d-BCD4-3A9C94FE9307}") = "FSharp.CompilerBinding", "FSharp.CompilerBinding\FSharp.CompilerBinding.fsproj", "{88F6940F-D300-474C-B2A7-E2ECD5B04B57}"
 EndProject


### PR DESCRIPTION
Without this change, VS 2010 Pro rejects the solution file for having being created by a newer version of VS. I don't know whether this would have side effects of any kind, but I saw a former VS PM do this on GitHub to solve the same problem for a different project, so I guess it's more or less ok.

Related to https://github.com/fsharp/fsharpbinding/issues/336
