### PR TITLE
Added conditions checks to tutorial project for both F# 3.0 and 3.1 as the tutorial project had F# 3.0 features

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -80,9 +80,15 @@
   <Extension path="/MonoDevelop/Ide/ProjectTemplates">
     <ProjectTemplate id="FSharpConsoleProject" file="templates.FSharpConsoleProject.xpt.xml"/>
     <ProjectTemplate id="FSharpLibraryProject" file="templates.FSharpLibraryProject.xpt.xml"/>
-    <!-- Only include the tutorial project if the F# 3.0 target is available as this includes F# 3.0 specific features -->
-    <Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets">
-      <ProjectTemplate id="FSharpTutorialProject" file="templates.FSharpTutorialProject.xpt.xml"/>
+    <!-- Only include the tutorial project if an F# 3.0 or 3.1 target is available as this includes F# 3.0 specific features -->
+	<ComplexCondition>
+		<Or>
+			<Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" />
+			<Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+		</Or>
+		<ProjectTemplate id="FSharpTutorialProject" file="templates.FSharpTutorialProject.xpt.xml"/>
+	</ComplexCondition>
+      
     </Condition>
     <ProjectTemplate id="FSharpGtkProject" file="templates.FSharpGtkProject.xpt.xml"/>
     <Condition id="Platform" value="windows">


### PR DESCRIPTION
Resolves Bugzilla 16725

private bug detailed below

```
1. Open XS.
2. Create 'F# 3.0 Tutorial project'
3. Build the application

Actual result:
Application gives 3 build error "This token is reserved for future use".
However with XS on mac this application is working fine.

Build output: https://gist.github.com/atin360/3243b357b38cd1937d14

Expected result:
Application should run successfully

Environment info:
Window 7 and 8
XS 4.2(build 207)- 767420f31da221c04d4e145991ff149f865334c0
```
