### PR TITLE
Prevent timeout from throwing an exception

### DIFF
--- a/FSharp.CompilerBinding/LanguageService.fs
+++ b/FSharp.CompilerBinding/LanguageService.fs
@@ -286,20 +286,18 @@ type LanguageService(dirtyNotify) =
     | Some (untyped,typed,_) when typed.HasFullTypeCheckInfo  -> Some (ParseAndCheckResults(typed, untyped))
     | _ -> None
 
-  member x.GetTypedParseResultWithTimeout(projectFilename, fileName:string, src, files, args, stale, timeout, targetFramework)  : ParseAndCheckResults = 
+  member x.GetTypedParseResultWithTimeout(projectFilename, fileName:string, src, files, args, stale, timeout, targetFramework)  : Option<ParseAndCheckResults> = 
     let opts = x.GetCheckerOptions(fileName, projectFilename, src, files, args, targetFramework)
     Debug.WriteLine("Parsing: Get typed parse result, fileName={0}", [|fileName|])
     // Try to get recent results from the F# service
-    match x.TryGetStaleTypedParseResult(fileName, opts, src, stale)  with
-    | Some results ->
+    match x.TryGetStaleTypedParseResult(fileName, opts, src, stale) with
+    | Some _ as results ->
         Debug.WriteLine(sprintf "Parsing: using stale results")
         results
     | None -> 
         Debug.WriteLine(sprintf "Worker: Not using stale results - trying typecheck with timeout")
         // If we didn't get a recent set of type checking results, we put in a request and wait for at most 'timeout' for a response
-        match mbox.TryPostAndReply((fun reply -> (fileName, src, opts, reply)), timeout = timeout) with
-        | Some x -> x
-        | None -> ParseAndCheckResults.Empty
+        mbox.TryPostAndReply((fun reply -> (fileName, src, opts, reply)), timeout = timeout)
 
   member x.GetTypedParseResultAsync(projectFilename, fileName:string, src, files, args, stale, targetFramework) = 
    async { 

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpResolverProvider.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpResolverProvider.fs
@@ -53,7 +53,7 @@ type FSharpLanguageItemTooltipProvider() =
         let files = CompilerArguments.getSourceFiles(extEditor.Project.Items) |> Array.ofList
         let args = CompilerArguments.getArgumentsFromProject(proj, config)
         let framework = CompilerArguments.getTargetFramework(proj.TargetFramework.Id)
-        let tyRes =
+        let tyResOpt =
             MDLanguageService.Instance.GetTypedParseResultWithTimeout
                  (extEditor.Project.FileName.ToString(),
                   editor.FileName, 
@@ -64,6 +64,9 @@ type FSharpLanguageItemTooltipProvider() =
                   ServiceSettings.blockingTimeout,
                   framework)
         Debug.WriteLine (sprintf "TooltipProvider: Getting tool tip")
+        match tyResOpt with
+        | None -> null
+        | Some tyRes ->
         // Get tool-tip from the language service
         let line, col, lineStr = MonoDevelop.getLineInfoFromOffset(offset, editor.Document)
         let tip = tyRes.GetToolTip(line, col, lineStr)
@@ -163,7 +166,7 @@ type FSharpResolverProvider() =
         let files = CompilerArguments.getSourceFiles(doc.Project.Items) |> Array.ofList
         let args = CompilerArguments.getArgumentsFromProject(proj, config)
         let framework = CompilerArguments.getTargetFramework(proj.TargetFramework.Id)
-        let tyRes = 
+        let tyResOpt = 
             MDLanguageService.Instance.GetTypedParseResultWithTimeout
                  (doc.Project.FileName.ToString(),
                   doc.Editor.FileName, 
@@ -175,7 +178,9 @@ type FSharpResolverProvider() =
                   framework)
 
         Debug.WriteLine("getting declaration location...")
-       
+        match tyResOpt with
+        | None -> null
+        | Some tyRes ->
         // Get the declaration location from the language service
         let line, col, lineStr = MonoDevelop.getLineInfoFromOffset(doc.Editor.Caret.Offset, doc.Editor.Document)
         let loc = tyRes.GetDeclarationLocation(line, col, lineStr)

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -199,16 +199,18 @@ type FSharpTextEditorCompletion() =
           loop 0 offset 
 
       Debug.WriteLine("Getting Parameter Info, startOffset = {0}", startOffset)
-      if docText = null || offset >= docText.Length || offset < 0 then null else
       let config = IdeApp.Workspace.ActiveConfiguration
-      if config = null then null else
+      if docText = null || config = null || offset >= docText.Length || offset < 0 then null else
 
       // Try to get typed result - with the specified timeout
       let proj = doc.Project :?> MonoDevelop.Projects.DotNetProject
       let files = CompilerArguments.getSourceFiles(doc.Project.Items) |> Array.ofList
       let args = CompilerArguments.getArgumentsFromProject(proj, config)
       let framework = CompilerArguments.getTargetFramework(proj.TargetFramework.Id)
-      let tyRes = MDLanguageService.Instance.GetTypedParseResultWithTimeout(doc.Project.FileName.ToString(), doc.Editor.FileName, docText, files, args, AllowStaleResults.MatchingFileName, ServiceSettings.blockingTimeout, framework)
+
+      match MDLanguageService.Instance.GetTypedParseResultWithTimeout(doc.Project.FileName.ToString(), doc.Editor.FileName, docText, files, args, AllowStaleResults.MatchingFileName, ServiceSettings.blockingTimeout, framework) with
+      | None -> null
+      | Some tyRes ->
       let line, col, lineStr = MonoDevelop.getLineInfoFromOffset(offset, doc.Editor.Document)
       let methsOpt = tyRes.GetMethods(line, col, lineStr)
       match methsOpt with 
@@ -279,14 +281,13 @@ type FSharpTextEditorCompletion() =
       let args = CompilerArguments.getArgumentsFromProject(proj, config)
       let framework = CompilerArguments.getTargetFramework(proj.TargetFramework.Id)
       // Try to get typed information from LanguageService (with the specified timeout)
-      let stale = if allowAnyStale then AllowStaleResults.MatchingFileName else  AllowStaleResults.MatchingSource
-      let tyRes = MDLanguageService.Instance.GetTypedParseResultWithTimeout(x.Document.Project.FileName.ToString(), x.Document.FileName.ToString(), x.Document.Editor.Text, files, args, stale, ServiceSettings.blockingTimeout, framework)
-
-      if tyRes = ParseAndCheckResults.Empty then
+      let stale = if allowAnyStale then AllowStaleResults.MatchingFileName else AllowStaleResults.MatchingSource
+      match MDLanguageService.Instance.GetTypedParseResultWithTimeout(x.Document.Project.FileName.ToString(), x.Document.FileName.ToString(), x.Document.Editor.Text, files, args, stale, ServiceSettings.blockingTimeout, framework) with
+      | None ->
         let result = CompletionDataList()
         result.Add(FSharpTryAgainMemberCompletionData())
         result :> ICompletionDataList
-      else
+      | Some tyRes ->
         // Get declarations and generate list for MonoDevelop
         let line, col, lineStr = MonoDevelop.getLineInfoFromOffset(context.TriggerOffset, x.Document.Editor.Document)
         match tyRes.GetDeclarations(line, col, lineStr) with


### PR DESCRIPTION
It seems cleaner that if the timeout is exceeded to just return an
empty typecheck results
