### PR TITLE
Set process coding system to utf-8-auto

### DIFF
--- a/emacs/fsharp-mode-completion.el
+++ b/emacs/fsharp-mode-completion.el
@@ -223,6 +223,7 @@ display in a help buffer instead.")
     (sleep-for 0.1)
     (if (process-live-p proc)
         (progn
+	  (set-process-coding-system proc 'utf-8-auto)
           (set-process-filter proc 'fsharp-ac-filter-output)
           (set-process-query-on-exit-flag proc nil)
           (setq fsharp-ac-status 'idle


### PR DESCRIPTION
The default-process-coding-system on GNU/Linux is utf-8-unix (no BOM).
This results in an json parsing error when json-read tries to parse
the BOM on the first line as JSON:

(wrong-type-argument hash-table-p "Error: F# completion process produced malformed JSON")

byte order mark:
efbb bf7b 224b 696e 6422 3a22 494e 464f  ...{"Kind":"INFO
