### PR TITLE
Fix for #418.

### DIFF
--- a/FSharp.CompilerBinding/LanguageService.fs
+++ b/FSharp.CompilerBinding/LanguageService.fs
@@ -27,7 +27,7 @@ type ParseAndCheckResults private (infoOpt: (CheckFileResults * ParseFileResults
         | Some (longName, residue) ->
             Debug.WriteLine (sprintf "GetDeclarations: '%A', '%s'" longName residue)
             // Get items & generate output
-            try Some (checkResults.GetDeclarationsAlternate(None, line, col, lineStr, longName, residue, fun (_,_) -> false)
+            try Some (checkResults.GetDeclarationsAlternate(Some parseResults, line, col, lineStr, longName, residue, fun (_,_) -> false)
                       |> Async.RunSynchronously, residue)
             with :? TimeoutException as e -> None
 

--- a/FSharp.CompilerBinding/Parser.fs
+++ b/FSharp.CompilerBinding/Parser.fs
@@ -201,10 +201,10 @@ module Parsing =
 
   /// Parse F# short-identifier and reverse the resulting string
   let parseBackIdent =  
-    parser { 
+    parser {
         let! x = optional (string "``")
         let! res = many (if x.IsSome then rawIdChar else fsharpIdentCharacter) |> map String.ofReversedSeq 
-        let! _ = optional (string "``") 
+        let! _ = optional (string "``")
         return res }
 
   /// Parse remainder of a long identifier before '.' (e.g. "Name.space.")
@@ -324,12 +324,5 @@ module Parsing =
         |> List.rev
         |> List.head
 
-    if String.IsNullOrEmpty residue &&
-       List.isEmpty longName &&
-       col >= 0 && col <= lineStr.Length &&
-       lineStr.[col - 1] = '.'
-    then
-        None
-    else
-        Some (longName, residue)
+    Some (longName, residue)
 


### PR DESCRIPTION
parseResults weren't being correctly passed into FSC.GetDeclarations, and
GetDeclarations was never called when an ident could not be found.

This brings back the annoying 'type-a-dot-anywhere' issue, this can be sorted later.
