### PR TITLE
Param completion

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -200,10 +200,10 @@ type FSharpTextEditorCompletion() =
               elif ((ch = ')' || ch = '}' || ch = ']')) then loop (depth+1) (i-1) 
               elif (ch = '(' || ch = '<') then i
               else loop depth (i-1) 
-          loop 0 (offset + 1)
+          loop 0 (offset-1)
 
       let config = IdeApp.Workspace.ActiveConfiguration
-      if docText = null || config = null || offset >= docText.Length || startOffset <= 0 || offset <= 0 then 
+      if docText = null || config = null || offset >= docText.Length || startOffset < 0 || offset <= 0 then 
         null 
       else
       Debug.WriteLine("Getting Parameter Info, startOffset = {0}", startOffset)


### PR DESCRIPTION
Attempt at #419.

Ctrl-Shift-Space now works, and you don't have to be positioned right after the '('.  

When deciding whether to pop up a Parameter completion, Instead of checking what character we're at, check what character was typed. This allows Ctrl-Shift-Space to work at these locations:

``` fsharp
let date = System.DateTime.Now.ToString(§  // Auto-opens here
let date = System.DateTime.Now.ToString(§)
let padded = date.PadRight(§   // Auto-opens here
let padded = date.PadRight(§2)
let padded = date.PadRight(2§)
```

Try it out and lets discuss here.
