### PR TITLE
Simple performance fix, which is noticeable when editing large files

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -364,7 +364,7 @@ module internal MonoDevelop =
     let getLineInfoFromOffset (offset, doc:Mono.TextEditor.TextDocument) = 
         let loc  = doc.OffsetToLocation(offset)
         let line, col = max loc.Line 1, loc.Column-1
-        let currentLine = doc.Lines |> Seq.nth (line-1)
+        let currentLine = doc.GetLineByOffset(offset)
         let lineStr = doc.Text.Substring(currentLine.Offset, currentLine.EndOffset - currentLine.Offset)
         (line, col, lineStr)
     


### PR DESCRIPTION
Instead of walking over each line (which is a red-black tree internally in MD) use the faster helper method GetLineByOffset in Monodevelop (This method implements a binary search). This is called every edit, navigate or hover.
