### PR TITLE
Compare bool fields by value of backing field rather than property.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/Parameters.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/Parameters.fs
@@ -93,20 +93,20 @@ type FSharpCompilerParameters() as this =
   member x.GenerateTailCalls
     with get() = asBool x.generateTailCalls
     and set(value) = 
-        if x.GenerateTailCalls <> value then 
+        if x.generateTailCalls <> asString value then 
             x.generateTailCalls <- asString value 
         
   member x.Optimize
     with get() = asBool x.optimize
     and set(value) = 
-        if x.Optimize <> value then 
+        if x.optimize <> asString value then 
             x.optimize <- asString value
             x.debugType <- (if x.DebugSymbols then (if x.Optimize then "pdbonly" else "full") else "none")
         
   member x.DebugSymbols
     with get() = asBool x.debugSymbols
     and set(value) = 
-        if x.DebugSymbols <> value then 
+        if x.debugSymbols <> asString value then 
             x.debugSymbols <- asString value
             x.debugType <- (if x.DebugSymbols then (if x.Optimize then "pdbonly" else "full") else "none")
         


### PR DESCRIPTION
When creating new projects the property value will be null, which means
the bool/string properties are never serialised.  This fixes #459
