### PR TITLE
Upgrade to FSC 0.0.44

### DIFF
--- a/FSharp.AutoComplete/FSharp.AutoComplete.fsproj
+++ b/FSharp.AutoComplete/FSharp.AutoComplete.fsproj
@@ -89,7 +89,7 @@
       <Name>FSharp.CompilerBinding</Name>
     </ProjectReference>
     <Reference Include="FSharp.Compiler.Service">
-      <HintPath>$(SolutionDir)\packages\FSharp.Compiler.Service.0.0.43\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\FSharp.Compiler.Service.0.0.44\lib\net40\FSharp.Compiler.Service.dll</HintPath>
     </Reference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the

--- a/FSharp.AutoComplete/packages.config
+++ b/FSharp.AutoComplete/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.Service" version="0.0.43" targetFramework="net40" />
+  <package id="FSharp.Compiler.Service" version="0.0.44" targetFramework="net40" />
 </packages>

--- a/FSharp.CompilerBinding/FSharp.CompilerBinding.fsproj
+++ b/FSharp.CompilerBinding/FSharp.CompilerBinding.fsproj
@@ -71,7 +71,7 @@
       <HintPath>..\lib\mono.cecil\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Compiler.Service">
-      <HintPath>$(SolutionDir)\packages\FSharp.Compiler.Service.0.0.43\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\FSharp.Compiler.Service.0.0.44\lib\net40\FSharp.Compiler.Service.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/FSharp.CompilerBinding/packages.config
+++ b/FSharp.CompilerBinding/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.Service" version="0.0.43" targetFramework="net40" />
+  <package id="FSharp.Compiler.Service" version="0.0.44" targetFramework="net40" />
 </packages>

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -74,10 +74,6 @@
     <Resolver class="MonoDevelop.FSharp.FSharpResolverProvider" mimeType="text/x-fsharp" />
   </Extension>
 
-  <Extension path = "/MonoDevelop/ProjectModel/SerializableClasses">
-    <DataType class = "MonoDevelop.FSharp.FSharpCompilerParameters" />
-  </Extension>
-
   <Extension path="/MonoDevelop/Ide/FileFilters">
     <FileFilter id="F#" insertbefore="AllFiles" _label="F# Source Files" extensions="*.fs;*.fsi;*.fsx;*.fsscript"/>
   </Extension>

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
@@ -233,7 +233,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Compiler.Editor">
-      <HintPath>packages\FSharp.Compiler.Service.0.0.43\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+      <HintPath>packages\FSharp.Compiler.Service.0.0.44\lib\net40\FSharp.Compiler.Service.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/monodevelop/MonoDevelop.FSharpBinding/packages.config
+++ b/monodevelop/MonoDevelop.FSharpBinding/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.Service" version="0.0.43" targetFramework="net40" />
+  <package id="FSharp.Compiler.Service" version="0.0.44" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Fixes #452: Travis build fails after upgrade to FCS 0.0.43.

@rneatherway: This fixes the issue in part, in that the blocking 300 ms delay is back. Travis VMs are not fast, and it seems to fail some times. You may want to adjust this period for integration tests. In that case, use the new property `DeclarationTextAsync` instead of `DeclarationText` and make your own timeout.

Tested on Mac, Windows and integration tests pass.
