### PR TITLE
master doesn't currently build.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/NRefactory.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/NRefactory.fs
@@ -54,9 +54,9 @@ module NRefactory =
         interface ISymbol with
             member x.SymbolKind = SymbolKind.Variable 
             member x.Name = name
-            member x.ToReference() =
-                { new ISymbolReference with 
-                  member x.Resolve(context) = this :> _}
+            //member x.ToReference() =
+            //    { new ISymbolReference with 
+            //      member x.Resolve(context) = this :> _}
         interface IVariable with 
             member x.Name = name
             member x.Region = region


### PR DESCRIPTION
A lot has been merged back and forth between vnext and master, and the interface `ISymbolReference` doesn't exist yet.
This commit just comments out the problem for now.
