### PR TITLE
Added LanguageName element = F# so it doesn't confuse the C# developers.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpScript.xft.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpScript.xft.xml
@@ -4,11 +4,8 @@
     <_Name>F# Script File</_Name>
     <Icon>md-text-file-icon|md-fs-script32</Icon>
     <_Description>Creates an empty F# script file.</_Description>
-
-    <!--This would create F#/General, which is a bit annoying if we have just two simple templates
     <_Category>General</_Category>
-    <LanguageName>F#</LanguageName> -->
-    <_Category>F#</_Category>
+    <LanguageName>F#</LanguageName>
   </TemplateConfiguration>
 
   <TemplateFiles>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSignature.xft.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSignature.xft.xml
@@ -8,10 +8,8 @@
     A signature file contains information about the public signatures of a set of F# program elements, such as types, namespaces, and modules. 
     
     It can be used to specify the accessibility of these program elements.</_Description>
-    <!--This would create F#/General, which is a bit annoying if we have just two simple templates
     <_Category>General</_Category>
-    <LanguageName>F#</LanguageName> -->
-    <_Category>F#</_Category>
+    <LanguageName>F#</LanguageName>
   </TemplateConfiguration>
 
   <TemplateFiles>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSource.xft.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSource.xft.xml
@@ -4,11 +4,8 @@
     <_Name>F# Source File</_Name>
     <Icon>md-text-file-icon|md-fs-logo32</Icon>
     <_Description>Creates an empty F# source file</_Description>
-
-    <!--This would create F#/General, which is a bit annoying if we have just two simple templates
     <_Category>General</_Category>
-    <LanguageName>F#</LanguageName> -->
-    <_Category>F#</_Category>
+    <LanguageName>F#</LanguageName>
   </TemplateConfiguration>
 
   <TemplateFiles>


### PR DESCRIPTION
This is for the 3 general file templates that don't have a language name element.
