### PR TITLE
Corrections to emacs syntax highlighting

### DIFF
--- a/emacs/fsharp-mode-font.el
+++ b/emacs/fsharp-mode-font.el
@@ -199,7 +199,7 @@
   (funcall (syntax-propertize-rules
             ("\\(@\\)\"" (1 (prog1 "|" (fsharp--syntax-string end)))) ; verbatim string
             ("\\(\"\\)\"\"" (1 (prog1 "|" (fsharp--syntax-string end)))) ; triple-quoted string
-            ("\\('\\)\\(?:[^\n\t\r\b\a\f\v\\\\]\\|\\\\[\"'ntrbafv]\\|\\\\u[0-9A-Fa-f]\\{4\\}\\|\\\\[0-9]\\{3\\}\\)\\('\\)"
+            ("\\('\\)\\(?:[^\n\t\r\b\a\f\v\\\\]\\|\\\\[\"'ntrbafv\\\\]\\|\\\\u[0-9A-Fa-f]\\{4\\}\\|\\\\[0-9]\\{3\\}\\)\\('\\)"
              (1 "|") (2 "|")) ; character literal
             ("\\((\\)/" (1 "()"))
             ("\\(/\\)\\*" (1 ".")))

--- a/emacs/fsharp-mode.el
+++ b/emacs/fsharp-mode.el
@@ -236,7 +236,7 @@ and whether it is in a project directory.")
         )
 
   ; Syntax highlighting
-  (setq font-lock-defaults '(fsharp-font-lock-keywords nil t))
+  (setq font-lock-defaults '(fsharp-font-lock-keywords))
   (setq syntax-propertize-function 'fsharp--syntax-propertize-function)
   ;; Error navigation
   (setq next-error-function 'fsharp-ac/next-error)


### PR DESCRIPTION
1. '\' was not highlighted as a character
2. Keyword syntax highlighting was case insensitive
