### PR TITLE
Change goto declaration to goto the code declaration rather than the signature file

### DIFF
--- a/FSharp.CompilerBinding/LanguageService.fs
+++ b/FSharp.CompilerBinding/LanguageService.fs
@@ -50,7 +50,7 @@ type ParseAndCheckResults private (infoOpt: (CheckFileResults * ParseFileResults
         | Some (checkResults, parseResults) -> 
         match Parsing.findLongIdents(col, lineStr) with 
         | None -> return FindDeclResult.DeclNotFound FindDeclFailureReason.Unknown
-        | Some(col,identIsland) -> return! checkResults.GetDeclarationLocationAlternate(line, col, lineStr, identIsland, true)
+        | Some(col,identIsland) -> return! checkResults.GetDeclarationLocationAlternate(line, col, lineStr, identIsland, false)
       }
     member x.GetMethods(line, col, lineStr) =
       async { 


### PR DESCRIPTION
Ideally we would toggle between the two but there is an issue in FCS
where if you are in a signature file there is no way to get the
definition file.  See https://github.com/fsharp/FSharp.Compiler.Service/issues/134
