### PR TITLE
Added hotfix commits from vnext-release to fix bugzilla 20102

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -291,18 +291,28 @@
   </Extension>
 
   <Extension path = "/MonoDevelop/SourceEditor2/ContextMenu/Editor">
-    <SeparatorItem id = "FSharpInteractiveStart" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendFile" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendSelection" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendLine" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendReferences" />
+    <ComplexCondition>
+      <Or>
+        <Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" />
+        <Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+      </Or>
+      <SeparatorItem id = "FSharpInteractiveStart" />
+      <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendSelection" />
+      <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendLine" />
+      <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendReferences" />
+    </ComplexCondition>
   </Extension>
 
   <Extension path = "/MonoDevelop/Ide/MainMenu/Edit">
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendFile" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendSelection" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendLine" />
-    <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendReferences" />
+    <ComplexCondition>
+      <Or>
+        <Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" />
+        <Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+      </Or>
+      <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendSelection" />
+      <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendLine" />
+      <CommandItem id = "MonoDevelop.FSharp.FSharpCommands.SendReferences" />
+    </ComplexCondition>
   </Extension>
 
   <!--- F# Android -->


### PR DESCRIPTION
Includes conditions around FSI integration in the IDE so that if F# is not installed it does not result in an unhanded exception in XS.
