### PR TITLE
Remove old make commands and don't default to building the pack files as this is not needed.

### DIFF
--- a/monodevelop/Makefile.orig
+++ b/monodevelop/Makefile.orig
@@ -29,23 +29,15 @@ endif
 
 .PHONY: all
 
-all: pack
+all: build
 
 build: MonoDevelop.FSharpBinding/MonoDevelop.FSharp.$(MDTAG).fsproj MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
 	(cd MonoDevelop.FSharpBinding && xbuild MonoDevelop.FSharp.$(MDTAG).fsproj /p:Configuration=$(config))
-
 
 pack: build
 	-rm -fr pack/$(VERSION)/$(MDTAG)/$(config)
 	@-mkdir -p pack/$(VERSION)/$(MDTAG)/$(config)
 	$(MDTOOL) setup pack bin/$(MDTAG)/$(config)/FSharpBinding.dll -d:pack/$(VERSION)/$(MDTAG)/$(config)
-
-add-libraries:
-	mkdir /Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/AddIns/AspNetMvc4
-	cp -pr dependencies/AspNetMvc4/* /Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/AddIns/AspNetMvc4
-
-remove-libraries:
-	rm -rf /Applications/MonoDevelop.app/Contents/MacOS/lib/monodevelop/AddIns/AspNetMvc4
 
 install: pack
 	$(MDTOOL) setup install -y pack/$(VERSION)/$(MDTAG)/$(config)/MonoDevelop.FSharpBinding_$(VERSION).mpack 


### PR DESCRIPTION
The pack stage is unnecessary for a normal build, and as the addin is part of MonoDevelop now we only need to use pack for an out of bounds build, which you can still do with make pack or make release.

`-add-libraries:` and `-remove-libraries:` commands are not used as the AspNetMvc4 files are now distributed with nuget.
