### PR TITLE
Fixed initialisation order in SingleView iOS projects

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/ios/SingleView/Common/AppDelegate.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/ios/SingleView/Common/AppDelegate.fs
@@ -8,12 +8,13 @@ open MonoTouch.Foundation
 type AppDelegate () =
     inherit UIApplicationDelegate ()
 
-    let window = new UIWindow (UIScreen.MainScreen.Bounds)
+    override val Window = null with get, set
 
     // This method is invoked when the application is ready to run.
     override this.FinishedLaunching (app, options) =
-        window.RootViewController <- new ${SafeProjectName}ViewController ()
-        window.MakeKeyAndVisible ()
+        this.Window <- new UIWindow (UIScreen.MainScreen.Bounds)
+        this.Window.RootViewController <- new ${SafeProjectName}ViewController ()
+        this.Window.MakeKeyAndVisible ()
         true
 
 module Main =


### PR DESCRIPTION
This is the same fix that was already applied to the Empty iOS projects.
Related bugzilla https://bugzilla.xamarin.com/show_bug.cgi?id=20957
