### PR TITLE
Add an indentation tracker that suits F# better. Fixes #256

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -187,7 +187,9 @@ type FSharpTextEditorCompletion() =
     // Extend any text editor that edits F# files
     CompilerArguments.supportedExtension(IO.Path.GetExtension(doc.FileName.ToString()))
 
-  override x.Initialize() = base.Initialize()
+  override x.Initialize() = 
+      do base.Document.Editor.IndentationTracker <- FSharpIndentationTracker(base.Document) :> Mono.TextEditor.IIndentationTracker 
+      base.Initialize()
 
   /// Provide parameter and method overload information when you type '(', '<' or ','
   override x.HandleParameterCompletion(context:CodeCompletionContext, completionChar:char) : MonoDevelop.Ide.CodeCompletion.ParameterDataProvider =

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
@@ -296,6 +296,7 @@
     <Compile Include="Services\InteractiveSession.fs" />
     <Compile Include="Services\NRefactory.fs" />
     <Compile Include="Services\NRefactoryCodeActionSource.fs" />
+    <Compile Include="Services\FSharpIndentationTracker.fs" />
     <Compile Include="FSharpInteractivePad.fs" />
     <Compile Include="FSharpOptionsPanels.fs" />
     <Compile Include="FSharpLanguageBinding.fs" />

--- a/monodevelop/MonoDevelop.FSharpBinding/Services/FSharpIndentationTracker.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/FSharpIndentationTracker.fs
@@ -1,0 +1,40 @@
+﻿namespace MonoDevelop.FSharp
+
+open System
+open MonoDevelop.Ide.Gui
+open MonoDevelop.Ide.Gui.Content
+open Mono.TextEditor
+
+type FSharpIndentationTracker(doc:Document) = 
+    let textDoc = doc.Editor.Document
+    let indentSize = doc.Editor.Options.IndentationSize
+
+    // Lines ending in these strings will be indented
+    let indenters = ["=";"do";"{";"[";"[|"]
+
+    let (|AddIndent|_|) (x:string) = 
+        let trimmed = x.TrimEnd() 
+        if indenters |> List.exists(trimmed.EndsWith) then Some indentSize
+        else None
+        
+    let rec getIndentation (line: DocumentLine) = 
+         if line = null then "" else
+         match textDoc.GetLineText(line.LineNumber) with
+         | x when String.IsNullOrWhiteSpace(x) -> getIndentation line.PreviousLine
+         | AddIndent i -> String(' ', line.GetIndentation(textDoc).Length + i)
+         | _ -> line.GetIndentation textDoc
+
+    let getIndentString lineNumber column =  
+         let line = textDoc.GetLine (lineNumber);
+         getIndentation line
+
+    interface IIndentationTracker with
+        member x.GetIndentationString (lineNumber, column) = getIndentString lineNumber column
+        member x.GetIndentationString (offset) = 
+            let loc = textDoc.OffsetToLocation (offset)
+            if doc.Editor.Caret.Column = 0 then "" else
+            getIndentString loc.Line loc.Column
+        member x.GetVirtualIndentationColumn (offset) = 
+            let loc = textDoc.OffsetToLocation (offset)
+            (getIndentString loc.Line loc.Column).Length
+        member x.GetVirtualIndentationColumn (lineNumber, column) = (getIndentString lineNumber column).Length


### PR DESCRIPTION
This avoid the issue in #256:

``` fsharp
let data = 
       [ ("Brazi", 10) ]

1 + 2§     // Pressing return here previously indented to the position of the "[" on the previous line.
```

Also avoids an unreported issue where pressing enter at the § would indent badly

``` fsharp
let a = 
    "some string"

§let b = 
    "some other string"
```

would result in 

``` fsharp
let a = 
    "some string"


        let b = 
    "some other string"
```

I'm sure we'll find issues with this indenter, but at least now we can fix them.
