### PR TITLE
Disable the virtual file system when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ monodevelop/Makefile
 /monodevelop/MonoDevelop.FSharpBinding/packages
 
 monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
+monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/tests

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestBase.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestBase.fs
@@ -35,7 +35,7 @@ type Util =
 
 type TestBase() =
     static let firstRun = ref true
-        
+    do MonoDevelop.FSharp.MDLanguageService.DisableVirtualFileSystem()
     abstract member Setup: unit -> unit
 
     [<TestFixtureSetUp>]


### PR DESCRIPTION
The VFS is implemented in FCS as a static singleton, hence this ugliness. We want to ensure that the VFS initialisation only occurs once, so it is now lazy. 
The tests need to call `MDLanguageService.DisableVirtualFileSystem` before anything reaches `MDLanguageService.Instance` and a language service is created.
