### PR TITLE
Added code templates to addin with four initial templates

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -93,6 +93,8 @@
     <Import file="Templates/ios/SingleView/ProjectIPhone.xpt.xml" />
     <Import file="Templates/ios/SingleView/ProjectUniversal.xpt.xml" />
     <Import file="Templates/ios/LibraryProject.xpt.xml" />
+    <!-- Code templates -->
+    <Import file = "Templates/FSharp-templates.xml" />
 
   </Runtime>
 
@@ -235,6 +237,10 @@
 
   <Extension path = "/MonoDevelop/ProjectModel/ProjectServiceExtensions">
     <Class class = "MonoDevelop.FSharp.FSharpProjectServiceExtension" />
+  </Extension>
+
+  <Extension path = "/MonoDevelop/Ide/CodeTemplates">
+    <CodeTemplate file="Templates/FSharp-templates.xml" />
   </Extension>
 
   <!-- F# interactive -->

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
@@ -286,7 +286,9 @@
     <None Include="Templates/ios/SingleView/Universal/ViewController.fs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-     
+    <None Include="Templates/FSharp-templates.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Compile Include="PowerPack\CodeDomVisitor.fs" />
     <Compile Include="PowerPack\CodeDomGenerator.fs" />
     <Compile Include="PowerPack\CodeProvider.fs" />

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharp-templates.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharp-templates.xml
@@ -1,0 +1,89 @@
+﻿<FSharpCodeTemplates version="1.0">
+
+  <CodeTemplate version="2.0">
+    <Header>
+      <_Group>F#</_Group>
+      <Version />
+      <MimeType>text/x-fsharp</MimeType>
+      <Shortcut>agent</Shortcut>
+      <_Description>Creates boilerplate vode for an agent</_Description>
+      <TemplateType>Unknown</TemplateType>
+    </Header>
+    <Variables>
+      <Variable name="var">
+        <Default>myAgent</Default>
+      </Variable>
+      <Variable name="typename">
+        <Default>string</Default>
+      </Variable>
+    </Variables>
+    <Code><![CDATA[let $var$ =
+    new MailboxProcessor<$typename$>(fun inbox ->
+       let rec loop () = 
+           async {
+               let! msg = inbox.Receive()
+               return! loop () }
+       loop ())
+$end$]]></Code>
+  </CodeTemplate>
+
+  <CodeTemplate version="2.0">
+    <Header>
+      <_Group>F#</_Group>
+      <Version />
+      <MimeType>text/x-fsharp</MimeType>
+      <Shortcut>outlet</Shortcut>
+      <_Description>Creates an iOS outlet with attribute.</_Description>
+      <TemplateType>Unknown</TemplateType>
+    </Header>
+    <Variables>
+      <Variable name="name">
+        <Default>Name</Default>
+      </Variable>
+      <Variable name="type">
+        <Default>UIButton</Default>
+      </Variable>
+    </Variables>
+    <Code><![CDATA[[<Outlet>]
+member val $name$ : $type$ = null with get,set]]></Code>
+  </CodeTemplate>
+
+  <CodeTemplate version="2.0">
+    <Header>
+      <_Group>F#</_Group>
+      <Version />
+      <MimeType>text/x-fsharp</MimeType>
+      <Shortcut>uncheck</Shortcut>
+      <_Description>Create an unchecked default value</_Description>
+      <TemplateType>Unknown</TemplateType>
+    </Header>
+    <Variables>
+      <Variable name="type">
+        <Default>notset</Default>
+      </Variable>
+    </Variables>
+    <Code><![CDATA[Unchecked.defaultof<$type$>]]></Code>
+  </CodeTemplate>
+
+  <CodeTemplate version="2.0">
+    <Header>
+      <_Group>F#</_Group>
+      <Version />
+      <MimeType>text/x-fsharp</MimeType>
+      <Shortcut>virt</Shortcut>
+      <_Description>Adds a virtual member</_Description>
+      <TemplateType>Unknown</TemplateType>
+    </Header>
+    <Variables>
+      <Variable name="funName">
+        <Default>notset</Default>
+      </Variable>
+      <Variable name="delta">
+        <Default>notset</Default>
+      </Variable>
+    </Variables>
+    <Code><![CDATA[abstract member $funName$ : int -> unit
+default this.$funName$ (delta:int) = ()]]></Code>
+  </CodeTemplate>
+
+</FSharpCodeTemplates>


### PR DESCRIPTION
`agent` to create a boilerplate agent
`outlet` to create iOS outlets with attribute
`uncheck` to wrap an unchecked<type> declaration
`virt` to create an abstract definition with default virtual

They are many more so please contribute. #648
