### PR TITLE
Add missing reference to test project after upgrading to XS 5.2.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj.orig
@@ -102,6 +102,9 @@
       <Private>False</Private>
       <HintPath>INSERT_FSPROJ_MDROOT\AddIns\MonoDevelop.Debugger\MonoDevelop.Debugger.dll</HintPath>
     </Reference>
+    <Reference Include="MonoDevelop.Projects.Formats.MSBuild">
+      <HintPath>INSERT_FSPROJ_MDROOT\bin\MonoDevelop.Projects.Formats.MSBuild.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/monodevelop/MonoDevelop.FSharpBinding/packages/repositories.config
+++ b/monodevelop/MonoDevelop.FSharpBinding/packages/repositories.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../../../FSharp.CompilerBinding/packages.config" />
   <repository path="../MonoDevelop.FSharp.Tests/packages.config" />
   <repository path="../packages.config" />
 </repositories>


### PR DESCRIPTION
After upgrading to XS 5.2 running the tests would fail with TypeInitializationException with a reference to a type from this dll.

Also, XS 5.2 made modifications to repositories.config, I thought it best just to include them.
