### PR TITLE
Add default filenames to F# file templates

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpScript.xft.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpScript.xft.xml
@@ -6,6 +6,7 @@
     <_Description>Creates an empty F# script file.</_Description>
     <_Category>General</_Category>
     <LanguageName>F#</LanguageName>
+    <DefaultFilename>Script.fsx</DefaultFilename>
   </TemplateConfiguration>
 
   <TemplateFiles>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSignature.xft.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSignature.xft.xml
@@ -10,6 +10,7 @@
     It can be used to specify the accessibility of these program elements.</_Description>
     <_Category>General</_Category>
     <LanguageName>F#</LanguageName>
+    <DefaultFilename>Class.fsi</DefaultFilename>
   </TemplateConfiguration>
 
   <TemplateFiles>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSource.xft.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/EmptyFSharpSource.xft.xml
@@ -6,6 +6,7 @@
     <_Description>Creates an empty F# source file</_Description>
     <_Category>General</_Category>
     <LanguageName>F#</LanguageName>
+    <DefaultFilename>Class.fs</DefaultFilename>
   </TemplateConfiguration>
 
   <TemplateFiles>


### PR DESCRIPTION
Fixes a minor annoyance: When you quickly want a throwaway `.fsx` file, you no longer have to bother to name it.
