### PR TITLE
Fix issues with the indenter and add some tests

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/IndentationTrackerTests.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/IndentationTrackerTests.fs
@@ -1,0 +1,127 @@
+﻿namespace MonoDevelop.FSharp.Tests
+open System
+open NUnit.Framework
+open MonoDevelop.FSharp
+open MonoDevelop.Core
+open MonoDevelop.Ide.Gui
+open MonoDevelop.Ide.Gui.Content
+open FSharp.CompilerBinding
+open MonoDevelop.Projects
+open MonoDevelop.Ide.TypeSystem
+open FsUnit
+open MonoDevelop.Debugger
+
+[<TestFixture>]
+type IndentationTrackerTests() =
+    inherit TestBase()
+    let mutable doc = Unchecked.defaultof<Document>
+
+    let content = """
+let a = 
+
+let b = (fun a ->
+
+  let b = a
+"""
+
+    let createDoc (text:string)=
+        let workbenchWindow = TestWorkbenchWindow()
+        let viewContent = new TestViewContent()
+
+        let project = new DotNetAssemblyProject ("F#", Name="test", FileName = FilePath("test.fsproj"))
+        let projectConfig = project.AddNewConfiguration("Debug")
+
+        TypeSystemService.LoadProject (project) |> ignore
+
+        viewContent.Project <- project
+
+        workbenchWindow.SetViewContent(viewContent)
+        viewContent.ContentName <- "/users/a.fs"
+        viewContent.GetTextEditorData().Document.MimeType <- "text/x-fsharp"
+        let doc = Document(workbenchWindow)
+        let textBuf = viewContent :> IEditableTextBuffer 
+        textBuf.Text <- text
+        textBuf.CursorPosition <- 0
+
+        let pfile = doc.Project.AddFile("/users/a.fs")
+
+        let textEditorCompletion = new FSharpTextEditorCompletion()
+        textEditorCompletion.Initialize(doc)
+        viewContent.Contents.Add(textEditorCompletion)
+
+        try doc.UpdateParseDocument() |> ignore
+        with exn -> Diagnostics.Debug.WriteLine(exn.ToString())
+        doc
+
+    let docWithCaret (content:string) = 
+        let d = createDoc(content.Replace("§", ""))
+        do match content.IndexOf('§') with
+           | -1 -> ()
+           | x  -> let l = d.Editor.OffsetToLocation(x)
+                   d.Editor.SetCaretTo(l.Line, l.Column)
+        d
+
+    let getBasicOffset expr =
+        let startOffset = content.IndexOf (expr, StringComparison.Ordinal)
+        startOffset + (expr.Length / 2)
+
+    let getIndent (doc:Document, content:string, line, col) =
+        doc.Editor.SetCaretTo(2, 2)
+        let column = doc.Editor.IndentationTracker.GetVirtualIndentationColumn(line, col)
+        column
+
+    [<TestFixtureSetUp>]
+    override x.Setup() =
+        base.Setup()
+        doc <- createDoc(content)
+
+    
+    [<Test>]
+    member x.BasicIndents() =
+       // let basicOffset = getBasicOffset (localVariable)
+        getIndent (doc, content, 3, 1) |> should equal 5
+        getIndent (doc, content, 5, 1) |> should equal 5
+        getIndent (doc, content, 7, 1) |> should equal 3
+
+
+    [<Test>]
+    member x.MatchExpression() =
+        let doc = docWithCaret("""let m = match 123 with§""")
+        doc.Editor.GetVirtualIndentationColumn(9)
+
+        |> should equal 9
+
+    [<Test>]
+    [<Ignore("InsertAtCaret doesn't simulate what happens when you press enter in MD, so this test currently fails")>]
+    member x.EnterDoesntChangeIndentationAtIndentPosition() =
+        let doc = docWithCaret("""  let a = 123
+  §let b = 321""")
+        doc.Editor.InsertAtCaret("\n")
+        doc.Editor.Document.Text 
+        |> should equal @"  let a = 123
+
+  let b = 321"
+
+    [<Test>]
+    member x.EnterDoesntChangeIndentationAtStartOfLine() =
+        let doc = docWithCaret("""  let a = 123
+§  let b = 321""")
+        doc.Editor.InsertAtCaret("\n")
+        doc.Editor.Document.Text 
+        |> should equal @"  let a = 123
+
+  let b = 321"
+
+    [<Test>]
+    [<Ignore("InsertAtCaret doesn't properly simulate what happens when you press enter in MD, so this test currently fails")>]
+    member x.EnterAfterEqualsIndents() =
+        let doc = docWithCaret """  let a = §123"""
+        doc.Editor.InsertAtCaret("\n")
+        doc.Editor.Document.Text 
+        |> should equal "  let a = 123\n      123"
+
+
+
+
+   
+

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj.orig
@@ -133,6 +133,7 @@
     <Compile Include="TestViewContent.fs" />
     <Compile Include="DebuggerExpressionResolver.fs" />
     <Compile Include="Checker.fs" />
+    <Compile Include="IndentationTrackerTests.fs" />
   </ItemGroup>
   <PropertyGroup>
     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>

--- a/monodevelop/MonoDevelop.FSharpBinding/Services/FSharpIndentationTracker.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/FSharpIndentationTracker.fs
@@ -10,7 +10,7 @@ type FSharpIndentationTracker(doc:Document) =
     let indentSize = doc.Editor.Options.IndentationSize
 
     // Lines ending in these strings will be indented
-    let indenters = ["=";"do";"{";"[";"[|";"->"]
+    let indenters = ["=";" do";"{";"[";"[|";"->";" try"]
 
     let (|AddIndent|_|) (x:string) = 
         if indenters |> List.exists(x.EndsWith) then Some ()
@@ -18,7 +18,12 @@ type FSharpIndentationTracker(doc:Document) =
     let (|Match|_|) (x:string) = 
         if x.EndsWith "with" && x.Contains("match ") then Some (x.LastIndexOf "match ")
         else None
-        
+
+    let initialWhiteSpace (s:string) offset = 
+        if offset >= s.Length then 0 else
+        let s = s.Substring offset
+        s.Length - s.TrimStart([|' '|]).Length
+                
     let rec getIndentation lineDistance (line: DocumentLine) = 
         if line = null then "" else
         match textDoc.GetLineText(line.LineNumber).TrimEnd() with
@@ -26,18 +31,28 @@ type FSharpIndentationTracker(doc:Document) =
         | Match i   when lineDistance < 2 -> String(' ', i)
         | AddIndent when lineDistance < 2 -> String(' ', line.GetIndentation(textDoc).Length + indentSize)
         | _ -> line.GetIndentation textDoc
-
+  
     let getIndentString lineNumber column =  
-        if doc.Editor.Caret.Column <= 1 then "" else
-        let line = textDoc.GetLine (lineNumber);
-        getIndentation 0 line
+        let caretColumn = doc.Editor.Caret.Column
+        let line = textDoc.GetLine lineNumber
+
+        let indentation = getIndentation 0 line
+        if line = null then indentation else
+        // Find white space in front of the caret and strip it out
+        let text = textDoc.GetLineText(line.LineNumber)
+        let reIndent = column = text.Length + 1 && caretColumn = 1 
+        if not reIndent then indentation else
+          let indent = getIndentation 0 (line.PreviousLine)
+          indent.Substring(initialWhiteSpace text 0)
 
     interface IIndentationTracker with
-        member x.GetIndentationString (lineNumber, column) = getIndentString lineNumber column
+        member x.GetIndentationString (lineNumber, column) =
+            getIndentString lineNumber column
         member x.GetIndentationString (offset) = 
             let loc = textDoc.OffsetToLocation (offset)
             getIndentString loc.Line loc.Column
         member x.GetVirtualIndentationColumn (offset) = 
             let loc = textDoc.OffsetToLocation (offset)
-            (getIndentString loc.Line loc.Column).Length
-        member x.GetVirtualIndentationColumn (lineNumber, column) = (getIndentString lineNumber column).Length
+            1 + (getIndentString loc.Line loc.Column).Length
+        member x.GetVirtualIndentationColumn (lineNumber, column) = 
+            1 + (getIndentString lineNumber column).Length


### PR DESCRIPTION
- One could not arrow left to go to the previous line
- Indents would be all wrong if you hit enter in the middle of a line
- Added indentation for `try`

There are two ignored tests. The behaviours work in MD/XS, but I don't know how to properly simulate hitting enter from the tests, so expected indentation doesn't happen.
