### PR TITLE
Flatten test namespaces

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/Checker.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/Checker.fs
@@ -1,4 +1,4 @@
-﻿namespace MonoDevelop.FSharp.Tests
+﻿namespace MonoDevelopTests
 open System
 open System.IO
 open FSharp.CompilerBinding

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/DebuggerExpressionResolver.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/DebuggerExpressionResolver.fs
@@ -1,4 +1,4 @@
-﻿namespace MonoDevelop.FSharp.Tests
+﻿namespace MonoDevelopTests
 open System
 open NUnit.Framework
 open MonoDevelop.FSharp

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/FSharpUnitTestTextEditorExtensionTests.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/FSharpUnitTestTextEditorExtensionTests.fs
@@ -1,4 +1,4 @@
-namespace MonoDevelop.FSharp.Tests
+namespace MonoDevelopTests
 open System
 open System.IO
 open NUnit.Framework

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/IndentationTrackerTests.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/IndentationTrackerTests.fs
@@ -1,4 +1,4 @@
-﻿namespace MonoDevelop.FSharp.Tests
+﻿namespace MonoDevelopTests
 open System
 open NUnit.Framework
 open MonoDevelop.FSharp

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestBase.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestBase.fs
@@ -1,4 +1,4 @@
-﻿namespace MonoDevelop.FSharp.Tests
+﻿namespace MonoDevelopTests
 open System
 open System.Reflection
 open System.IO

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestViewContent.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestViewContent.fs
@@ -1,4 +1,4 @@
-﻿namespace MonoDevelop.FSharp.Tests
+﻿namespace MonoDevelopTests
 open System
 open System.Linq
 open MonoDevelop.Core

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestWorkbenchWindow.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.Tests/TestWorkbenchWindow.fs
@@ -1,4 +1,4 @@
-﻿namespace MonoDevelop.FSharp.Tests
+﻿namespace MonoDevelopTests
 open System
 open Mono.Addins
 open MonoDevelop.Ide.Gui


### PR DESCRIPTION
Forgive this silly PR but this has annoyed me for a while: clickety-clickety-clickety-click
This flattens the namespaces of our MD tests, because the tooling is not all that good.
![clickety](https://cloud.githubusercontent.com/assets/445888/3577965/f9f9099c-0ba2-11e4-9127-f2449120de8f.gif)
