### PR TITLE
Add new code templates to F# in XS

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharp-templates.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharp-templates.xml
@@ -75,49 +75,6 @@ member this.$name$ (sender : $type$) =
       <_Group>F#</_Group>
       <Version />
       <MimeType>text/x-fsharp</MimeType>
-      <Shortcut>du</Shortcut>
-      <_Description>Template for Discriminated Unions</_Description>
-      <TemplateType>Expansion</TemplateType>
-    </Header>
-    <Variables>
-      <Variable name="name">
-        <Default>name</Default>
-      </Variable>
-      <Variable name="case">
-        <Default>case</Default>
-      </Variable>
-    </Variables>
-    <Code><![CDATA[type $name$ = 
-    | $case$ $end$]]></Code>
-  </CodeTemplate>
-
-    <CodeTemplate version="2.0">
-    <Header>
-      <_Group>F#</_Group>
-      <Version />
-      <MimeType>text/x-fsharp</MimeType>
-      <Shortcut>interface</Shortcut>
-      <_Description>Template for interface implementation</_Description>
-      <TemplateType>Expansion</TemplateType>
-    </Header>
-    <Variables>
-      <Variable name="name">
-        <Default>name</Default>
-      </Variable>
-      <Variable name="interface">
-        <Default>IDisposable</Default>
-      </Variable>
-    </Variables>
-    <Code><![CDATA[type $name$ =
-    interface $interface$ with 
-        &end&]]></Code>
-  </CodeTemplate>
-
-  <CodeTemplate version="2.0">
-    <Header>
-      <_Group>F#</_Group>
-      <Version />
-      <MimeType>text/x-fsharp</MimeType>
       <Shortcut>uncheck</Shortcut>
       <_Description>Creates an unchecked default value</_Description>
       <TemplateType>Unknown</TemplateType>


### PR DESCRIPTION
Current templates: `agent`, `outlet`, `action`, `du`, `interface`, `unchecked`, `check`, `virt`, `abstract`, `abstractp`, `seq`, `list`, `array`, `struct`, `if`, `elif`, `ifelse`, `while`, `fort`, `fordt`, `fori`, `match`, `fun`, `main`, `tomap`
