### PR TITLE
Added an event listener to call ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients when a solution is closed

### DIFF
--- a/FSharp.CompilerBinding/LanguageService.fs
+++ b/FSharp.CompilerBinding/LanguageService.fs
@@ -385,3 +385,6 @@ type LanguageService(dirtyNotify) =
     return refs }
 
   member x.InvalidateConfiguration(options) = checker.InvalidateConfiguration(options)
+
+  member x.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients() =
+      checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
@@ -80,6 +80,7 @@ type FSharpLanguageBinding() =
       IdeApp.Workspace.FileRenamedInProject.Add(invalidateAll)
       IdeApp.Workspace.ReferenceAddedToProject.Add(fun r -> invalidateProjectFile(r.Project))
       IdeApp.Workspace.ReferenceRemovedFromProject.Add(fun r -> invalidateProjectFile(r.Project))
+      IdeApp.Workspace.SolutionUnloaded.Add(fun _ -> MDLanguageService.Instance.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients())
 
     
   // ----------------------------------------------------------------------------


### PR DESCRIPTION
This should free up memory when closing a solution.
