### PR TITLE
[MonoDevelop] Fix Release configuration issue

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
@@ -115,7 +115,7 @@ type FSharpLanguageBinding() =
               pars.GenerateTailCalls <- false
           let releaseAtt = options.GetAttribute ("Release")
           if (System.String.Compare ("True", releaseAtt, StringComparison.OrdinalIgnoreCase) = 0) then
-              pars.DebugSymbols <- true
+              pars.DebugSymbols <- false
               pars.Optimize <- true
               pars.GenerateTailCalls <- true
       // TODO: set up the documentation file to be AssemblyName.xml by default (but how do we get AssemblyName here?)


### PR DESCRIPTION
When creating the Release configuration of a new project, set DebugSymbols to false instead of true.
This fixes BXC bug #20438.
