### PR TITLE
Added UnformattedTextFileDescriptionTemplate so F# files are not forced ...

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -179,6 +179,10 @@
     <FileFilter id="F#" insertbefore="AllFiles" _label="F# Source Files" extensions="*.fs;*.fsi;*.fsx;*.fsscript"/>
   </Extension>
 
+  <Extension path = "/MonoDevelop/Ide/FileTemplateTypes">
+    <FileTemplateType name = "UnformattedFile" class = "MonoDevelop.FSharp.UnformattedTextFileDescriptionTemplate"/>
+  </Extension>
+
   <Extension path="/MonoDevelop/Ide/FileTemplates">
     <FileTemplate id="EmptyFSharpSource" file="Templates/EmptyFSharpSource.xft.xml"/>
     <FileTemplate id="EmptyFSharpScript" file="Templates/EmptyFSharpScript.xft.xml"/>

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
@@ -405,6 +405,7 @@
     <Compile Include="FSharpFormattingPolicyPanel.fs" />
 	  <Compile Include="FSharpSyntaxMode.fs" />
 	  <Compile Include="FSharpHighlightUsagesExtension.fs" />
+    <Compile Include="UnformattedTextFileDescriptionTemplate.fs" />
 	  <EmbeddedResource Include="FSharpSyntaxMode.xml" />
     <EmbeddedResource Include="FSharpFormattingPolicy.xml" />
     <EmbeddedResource Include="FSharpStylePolicy.xml" />

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/CustomKeyboardExtension/Project.xpt.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/CustomKeyboardExtension/Project.xpt.xml
@@ -25,9 +25,9 @@
 			<Files>
 				<Directory name="Resources"/>
 				<File name="Info.plist" AddStandardHeader="False" src="Info.plist.xml" />
-				<File name="Conversions.fs" AddStandardHeader="True" src="../Common/Conversions.fs" />
-				<File name="KeyboardViewController.fs" AddStandardHeader="True" src="KeyboardViewController.fs" />
-				<File name="AppDelegate.fs" AddStandardHeader="True" src="../Common/ExtensionAppDelegate.fs" />
+				<UnformattedFile name="Conversions.fs" AddStandardHeader="True" src="../Common/Conversions.fs" />
+				<UnformattedFile name="KeyboardViewController.fs" AddStandardHeader="True" src="KeyboardViewController.fs" />
+				<UnformattedFile name="AppDelegate.fs" AddStandardHeader="True" src="../Common/ExtensionAppDelegate.fs" />
 			</Files>
 		</Project>
 	</Combine>

--- a/monodevelop/MonoDevelop.FSharpBinding/UnformattedTextFileDescriptionTemplate.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/UnformattedTextFileDescriptionTemplate.fs
@@ -1,0 +1,56 @@
+namespace MonoDevelop.FSharp
+open System
+open System.Collections.Generic
+open System.IO
+open MonoDevelop.Ide.Templates
+open MonoDevelop.Core
+open MonoDevelop.Projects
+open MonoDevelop.Ide.StandardHeader
+open System.Text
+open MonoDevelop.Ide.Gui.Content
+
+type UnformattedTextFileDescriptionTemplate() =
+    inherit TextFileDescriptionTemplate()
+
+    override x.CreateFileContent(policyParent, project, language, fileName, identifier) =
+        let tags = new Dictionary<_, _> ()
+        x.ModifyTags (policyParent, project, language, identifier, fileName, ref tags)
+                       
+        let ms = new MemoryStream ()
+
+        let bom = Encoding.UTF8.GetPreamble ()
+        ms.Write (bom, 0, bom.Length)
+
+        if x.AddStandardHeader then
+            let header = StandardHeaderService.GetHeader (policyParent, fileName, true)
+            let data = System.Text.Encoding.UTF8.GetBytes header
+            ms.Write (data, 0, data.Length)
+
+        let doc =
+            let content = x.CreateContent (project, tags, language)
+            let content = StringParserService.Parse (content, tags)
+            new Mono.TextEditor.TextDocument (Text = content)
+            
+        let textPolicy =
+            match policyParent with
+            | null -> Policies.PolicyService.GetDefaultPolicy<TextStylePolicy> "text/plain"
+            | p -> p.Policies.Get<TextStylePolicy> "text/plain"
+             
+        let eolMarker = TextStylePolicy.GetEolMarker textPolicy.EolMarker
+        let eolMarkerBytes = Encoding.UTF8.GetBytes eolMarker
+                        
+           
+        for line in doc.Lines do
+            let lineText =
+                let lt = doc.GetTextAt (line.Offset, line.Length)
+                if textPolicy.TabsToSpaces then
+                    let tab = String.replicate textPolicy.TabWidth " "
+                    lt.Replace ("\t", tab)
+                else lt
+
+            let data = Encoding.UTF8.GetBytes lineText
+            ms.Write (data, 0, data.Length)
+            ms.Write (eolMarkerBytes, 0, eolMarkerBytes.Length)
+            
+        ms.Position <- 0L
+        ms :> _


### PR DESCRIPTION
...to be formatted during creation

Updated CustomKeyboardExtension to use the new
UnformattedTextFileDescriptionTemplate to avoid formatting.
