### PR TITLE
Improve semantic formatting

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
@@ -16,31 +16,7 @@ open MonoDevelop.Ide.CodeCompletion
 open Gdk
 open MonoDevelop.Components
 open Microsoft.FSharp.Compiler.SourceCodeServices
-
-[<AutoOpen>]
-module FSharpTypeExt =
-    let isOperatorOrActivePattern (name: string) =
-            if name.StartsWith "( " && name.EndsWith " )" && name.Length > 4 then
-                name.Substring (2, name.Length - 4) |> String.forall (fun c -> c <> ' ')
-            else false
-
-    let rec getAbbreviatedType (fsharpType: FSharpType) =
-        if fsharpType.IsAbbreviation then
-            let typ = fsharpType.AbbreviatedType
-            if typ.HasTypeDefinition then getAbbreviatedType typ
-            else fsharpType
-        else fsharpType
-
-    let isConstructor (func: FSharpMemberFunctionOrValue) =
-        func.DisplayName = ".ctor"
-
-    let isReferenceCell (fsharpType: FSharpType) = 
-        let ty = getAbbreviatedType fsharpType
-        ty.HasTypeDefinition && ty.TypeDefinition.IsFSharpRecord && ty.TypeDefinition.FullName = "Microsoft.FSharp.Core.FSharpRef`1"
-    
-    type FSharpType with
-        member x.IsReferenceCell =
-            isReferenceCell x
+open MonoDevelop.FSharp.FSharpSymbolHelper
 
 type XmlDoc =
   ///A full xmldoc tooltip


### PR DESCRIPTION
Add extra punctuation types for common symbols:
:: |> ! _ :> :?> :? || &&
Added extra bracket punctuation for attributes type defs, arrays:
[< >] < > [| |]
Added support for Properties, Fields, Functions, Vals, Delegate, Event.
Added fix for FCS reporting ranges spanning the whole symbol content
rather than the ident segment, uses the right column alignment instead.
