### PR TITLE
Refactored Tooltip code to remove some MonoDevelop UI dependencies

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -1,7 +1,11 @@
 ﻿module MonoDevelop.FSharp.FSharpSymbolHelper
 open System
+open System.Collections.Generic
 open System.Reflection
 open Microsoft.FSharp.Compiler.SourceCodeServices
+open Mono.TextEditor
+open MonoDevelop.Ide
+open MonoDevelop.Components
 
 [<AutoOpen>]
 module FSharpTypeExt =
@@ -45,6 +49,7 @@ module FSharpTypeExt =
             | :? MethodInfo as mi -> mi.GetBaseDefinition().DeclaringType
             | _ -> this.DeclaringType
 
+[<AutoOpen>]
 module CorePatterns =
     let (|ActivePatternCase|_|) (symbol : FSharpSymbol) =
         match symbol with
@@ -86,6 +91,7 @@ module CorePatterns =
         | :? FSharpUnionCase as uc-> UnionCase(uc) |> Some
         | _ -> None
 
+[<AutoOpen>]
 module ExtendedPatterns = 
     let (|TypeAbbreviation|_|) symbol =
         match symbol with
@@ -121,8 +127,7 @@ module ExtendedPatterns =
             when not (isConstructor symbol) ->
                 if symbol.FullType.IsFunctionType 
                     && not symbol.IsPropertyGetterMethod 
-                    && not symbol.IsPropertySetterMethod 
-                    && not symbolUse.IsFromComputationExpression then 
+                    && not symbol.IsPropertySetterMethod then 
                     if FSharpTypeExt.isOperatorOrActivePattern symbol.DisplayName then
                         if symbolUse.IsFromPattern then Pattern
                         else Operator
@@ -166,3 +171,316 @@ module ExtendedPatterns =
         match symbol with
         | CorePatterns.Entity symbol when symbol.IsValueType -> Some(ValueType)
         | _ -> None
+
+type XmlDoc =
+  ///A full xmldoc tooltip
+| Full of string
+  ///A lookup of key, filename
+| Lookup of string * string option
+  ///No xmldoc
+| EmptyDoc
+
+type ToolTips =
+  ///A ToolTip of signature, summary
+| ToolTip of string * XmlDoc
+  ///A empty tip
+| EmptyTip
+
+[<AutoOpen>]
+module internal Highlight =
+    type HighlightType =
+    | Symbol | Keyword | UserType | Number
+
+    let getColourScheme () =
+        Highlighting.SyntaxModeService.GetColorStyle (IdeApp.Preferences.ColorScheme)
+
+    let hl str (style: Highlighting.ChunkStyle) =
+        let color = getColourScheme().GetForeground (style) |> GtkUtil.ToGdkColor
+        let colorString = HelperMethods.GetColorString (color)
+        sprintf """<span foreground="%s">%s</span>""" colorString str
+
+    let asType t s =
+        let cs = getColourScheme ()
+        match t with
+        | Symbol -> hl s cs.KeywordOperators
+        | Keyword -> hl s cs.KeywordTypes
+        | UserType -> hl s cs.UserTypes
+        | Number -> hl s cs.Number
+
+type TooltipResults =
+| ParseAndCheckNotFound
+| NoToolTipText
+| NoToolTipData
+| Tooltip of TooltipItem
+
+module SymbolTooltips =
+
+    let internal escapeText = GLib.Markup.EscapeText
+
+    /// Concat two strings with a space between if both a and b are not IsNullOrWhiteSpace
+    let internal (++) (a:string) (b:string) =
+        match String.IsNullOrEmpty a, String.IsNullOrEmpty b with
+        | true, true -> ""
+        | false, true -> a
+        | true, false -> b
+        | false, false -> a + " " + b
+
+    let getSummaryFromSymbol (symbol:FSharpSymbol) (backupSig: Lazy<Option<string * string>> option) =
+        let xmlDoc, xmlDocSig = 
+            match symbol with
+            | :? FSharpMemberFunctionOrValue as func -> func.XmlDoc, func.XmlDocSig
+            | :? FSharpEntity as fse -> fse.XmlDoc, fse.XmlDocSig
+            | :? FSharpField as fsf -> fsf.XmlDoc, fsf.XmlDocSig
+            | :? FSharpUnionCase as fsu -> fsu.XmlDoc, fsu.XmlDocSig
+            | :? FSharpActivePatternCase as apc -> apc.XmlDoc, apc.XmlDocSig
+            | :? FSharpGenericParameter as gp -> gp.XmlDoc, ""
+            | _ -> ResizeArray() :> IList<_>, ""
+
+        if xmlDoc.Count > 0 then Full (String.Join( "\n", xmlDoc |> Seq.map escapeText))
+        else
+            if String.IsNullOrWhiteSpace xmlDocSig then
+                match backupSig with
+                | Some backup ->
+                     match backup.Force() with
+                     | Some (key, file) ->Lookup (key, Some file)
+                     | None -> XmlDoc.EmptyDoc
+                | None -> XmlDoc.EmptyDoc
+            else Lookup(xmlDocSig, symbol.Assembly.FileName)
+
+    let getUnioncaseSignature displayContext (unionCase:FSharpUnionCase) =
+        if unionCase.UnionCaseFields.Count > 0 then
+           let typeList =
+              unionCase.UnionCaseFields
+              |> Seq.map (fun unionField -> unionField.Name ++ asType Symbol ":" ++ asType UserType (escapeText (unionField.FieldType.Format displayContext)))
+              |> String.concat (asType Symbol " * " )
+           unionCase.Name ++ asType Keyword "of" ++ typeList
+         else unionCase.Name
+
+    let getEntitySignature displayContext (fse: FSharpEntity) =
+        let modifier =
+            match fse.Accessibility with
+            | a when a.IsInternal -> asType Keyword "internal "
+            | a when a.IsPrivate -> asType Keyword "private "
+            | _ -> ""
+
+        let typeName =
+            match fse with
+            | _ when fse.IsFSharpModule -> "module"
+            | _ when fse.IsEnum         -> "enum"
+            | _ when fse.IsValueType    -> "struct"
+            | _                         -> "type"
+
+        let enumtip () =
+            asType Symbol " =" + "\n" + 
+            asType Symbol "|" ++
+            (fse.FSharpFields
+            |> Seq.filter (fun f -> not f.IsCompilerGenerated)
+            |> Seq.map (fun field -> match field.LiteralValue with
+                                     | Some lv -> field.Name + asType Symbol " = " + asType Number (string lv)
+                                     | None -> field.Name )
+            |> String.concat ("\n" + asType Symbol "| " ) )
+
+
+        let uniontip () = 
+            asType Symbol " =" + "\n" + 
+            asType Symbol "|" ++
+            (fse.UnionCases 
+            |> Seq.map (getUnioncaseSignature displayContext)
+            |> String.concat ("\n" + asType Symbol "| " ) )
+                                 
+        let typeDisplay = modifier + asType Keyword typeName ++ asType UserType fse.DisplayName
+        let fullName = "\n\nFull name: " + fse.FullName
+        match fse.IsFSharpUnion, fse.IsEnum with
+        | true, false -> typeDisplay + uniontip () + fullName
+        | false, true -> typeDisplay + enumtip () + fullName
+        | _ -> typeDisplay + fullName
+
+    let getFuncSignature displayContext (func: FSharpMemberFunctionOrValue) =
+        let functionName =
+            if isConstructor func then func.EnclosingEntity.DisplayName
+            else func.DisplayName
+
+        let modifiers =
+            let accessibility =
+                match func.Accessibility with
+                | a when a.IsInternal -> asType Keyword "internal"
+                | a when a.IsPrivate -> asType Keyword "private"
+                | _ -> ""
+
+            let modifier =
+                //F# types are prefixed with new, should non F# types be too for consistancy?
+                if isConstructor func then
+                    if func.EnclosingEntity.IsFSharp then "new" ++ accessibility
+                    else accessibility
+                elif func.IsMember then 
+                    if func.IsInstanceMember then
+                        if func.IsDispatchSlot then "abstract member" ++ accessibility
+                        else "member" ++ accessibility
+                    else "static member" ++ accessibility
+                else
+                    if func.InlineAnnotation = FSharpInlineAnnotation.AlwaysInline then "val" ++ accessibility ++ "inline"
+                    elif func.IsInstanceMember then "val" ++ accessibility
+                    else "val" ++ accessibility //does this need to be static prefixed?
+            modifier
+
+        let argInfos =
+            func.CurriedParameterGroups 
+            |> Seq.map Seq.toList 
+            |> Seq.toList 
+
+        let retType = asType UserType (escapeText(func.ReturnParameter.Type.Format displayContext))
+
+        let padLength = 
+            let allLengths = argInfos |> List.concat |> List.map (fun p -> p.DisplayName.Length)
+            match allLengths with
+            | [] -> 0
+            | l -> l |> List.max
+
+        match argInfos with
+        | [] ->
+            //When does this occur, val type within  module?
+            asType Keyword modifiers ++ functionName ++ asType Symbol ":" ++ retType
+                   
+        | [[]] ->
+            //A ctor with () parameters seems to be a list with an empty list
+            asType Keyword modifiers ++ functionName ++ asType Symbol "() :" ++ retType 
+        | many ->
+                let allParams =
+                    many
+                    |> List.map(fun listOfParams ->
+                                    listOfParams
+                                    |> List.map(fun p -> "   " + p.DisplayName.PadRight (padLength) + asType Symbol ":" ++ asType UserType (escapeText (p.Type.Format displayContext)))
+                                    |> String.concat (asType Symbol " *" ++ "\n"))
+                    |> String.concat (asType Symbol " ->" + "\n") 
+                let typeArguments =
+                    allParams +  "\n   " + (String.replicate (max (padLength-1) 0) " ") +  asType Symbol "->" ++ retType
+                asType Keyword modifiers ++ functionName ++ asType Symbol ":" + "\n" + typeArguments
+
+    let getValSignature displayContext (v:FSharpMemberFunctionOrValue) =
+        let retType = asType UserType (escapeText(v.ReturnParameter.Type.Format displayContext))
+        let prefix = 
+            if v.IsMutable then asType Keyword "val" ++ asType Keyword "mutable"
+            else asType Keyword "val"
+        prefix ++ v.DisplayName ++ asType Symbol ":" ++ retType
+
+    let getFieldSignature displayContext (field: FSharpField) =
+        let retType = asType UserType (escapeText(field.FieldType.Format displayContext))
+        match field.LiteralValue with
+        | Some lv -> field.DisplayName ++ asType Symbol ":" ++ retType ++ asType Symbol "=" ++ asType Number (string lv)
+        | None ->
+            let prefix = 
+                if field.IsMutable then asType Keyword "val" ++ asType Keyword "mutable"
+                else asType Keyword "val"
+            prefix ++ field.DisplayName ++ asType Symbol ":" ++ retType
+
+    let getTooltipFromSymbolUse (symbolUse:FSharpSymbolUse) (backUpSig: Lazy<_> option) =
+        match symbolUse.Symbol with
+        | Entity fse ->
+            try
+                let signature = getEntitySignature symbolUse.DisplayContext fse
+                ToolTip(signature, getSummaryFromSymbol fse backUpSig)
+            with exn -> ToolTips.EmptyTip
+
+        | MemberFunctionOrValue func ->
+            try
+            if isConstructor func then 
+                if func.EnclosingEntity.IsValueType || func.EnclosingEntity.IsEnum then
+                    //ValueTypes
+                    let signature = getFuncSignature symbolUse.DisplayContext func
+                    ToolTip(signature, getSummaryFromSymbol func backUpSig)
+                else
+                    //ReferenceType constructor
+                    let signature = getFuncSignature symbolUse.DisplayContext func
+                    ToolTip(signature, getSummaryFromSymbol func backUpSig)
+
+            elif func.FullType.IsFunctionType && not func.IsPropertyGetterMethod && not func.IsPropertySetterMethod && not symbolUse.IsFromComputationExpression then 
+                if isOperatorOrActivePattern func.DisplayName then
+                    //Active pattern or operator
+                    let signature = getFuncSignature symbolUse.DisplayContext func
+                    ToolTip(signature, getSummaryFromSymbol func backUpSig)
+                else
+                    //closure/nested functions
+                    if not func.IsModuleValueOrMember then
+                        //represents a closure or nested function, needs FCS support
+                        let signature = func.FullType.Format symbolUse.DisplayContext
+                        let summary = getSummaryFromSymbol func backUpSig
+                        ToolTip(signature, summary)
+                    else
+                        let signature = getFuncSignature symbolUse.DisplayContext func
+                        ToolTip(signature, getSummaryFromSymbol func backUpSig)                            
+
+            else
+                //val name : Type
+                let signature = getValSignature symbolUse.DisplayContext func
+                ToolTip(signature, getSummaryFromSymbol func backUpSig)
+            with exn -> ToolTips.EmptyTip
+
+        | Field fsf ->
+            let signature = getFieldSignature symbolUse.DisplayContext fsf
+            ToolTip(signature, getSummaryFromSymbol fsf backUpSig)
+
+        | UnionCase uc ->
+            let signature = getUnioncaseSignature symbolUse.DisplayContext uc
+            ToolTip(signature, getSummaryFromSymbol uc backUpSig)
+
+        | ActivePatternCase apc ->
+            //Theres not enough information to build this?
+            ToolTips.EmptyTip
+           
+        | _ -> ToolTips.EmptyTip
+
+    let getTooltipFromSymbol (symbol:FSharpSymbol) displayContext (backUpSig: Lazy<_> option) =
+        match symbol with
+        | Entity fse ->
+            try
+                let signature = getEntitySignature displayContext fse
+                ToolTip(signature, getSummaryFromSymbol fse backUpSig)
+            with exn -> ToolTips.EmptyTip
+
+        | MemberFunctionOrValue func ->
+            try
+            if isConstructor func then 
+                if func.EnclosingEntity.IsValueType || func.EnclosingEntity.IsEnum then
+                    //ValueTypes
+                    let signature = getFuncSignature displayContext func
+                    ToolTip(signature, getSummaryFromSymbol func backUpSig)
+                else
+                    //ReferenceType constructor
+                    let signature = getFuncSignature displayContext func
+                    ToolTip(signature, getSummaryFromSymbol func backUpSig)
+
+            elif func.FullType.IsFunctionType && not func.IsPropertyGetterMethod && not func.IsPropertySetterMethod (*&& not symbolUse.IsFromComputationExpression*) then 
+                if isOperatorOrActivePattern func.DisplayName then
+                    //Active pattern or operator
+                    let signature = getFuncSignature displayContext func
+                    ToolTip(signature, getSummaryFromSymbol func backUpSig)
+                else
+                    //closure/nested functions
+                    if not func.IsModuleValueOrMember then
+                        //represents a closure or nested function, needs FCS support
+                        let signature = func.FullType.Format displayContext
+                        let summary = getSummaryFromSymbol func backUpSig
+                        ToolTip(signature, summary)
+                    else
+                        let signature = getFuncSignature displayContext func
+                        ToolTip(signature, getSummaryFromSymbol func backUpSig)                            
+
+            else
+                //val name : Type
+                let signature = getValSignature displayContext func
+                ToolTip(signature, getSummaryFromSymbol func backUpSig)
+            with exn -> ToolTips.EmptyTip
+
+        | Field fsf ->
+            let signature = getFieldSignature displayContext fsf
+            ToolTip(signature, getSummaryFromSymbol fsf backUpSig)
+
+        | UnionCase uc ->
+            let signature = getUnioncaseSignature displayContext uc
+            ToolTip(signature, getSummaryFromSymbol uc backUpSig)
+
+        | ActivePatternCase apc ->
+            //Theres not enough information to build this?
+            ToolTips.EmptyTip
+           
+        | _ -> ToolTips.EmptyTip

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
@@ -6,283 +6,16 @@ namespace MonoDevelop.FSharp
 
 open System
 open System.IO
-open System.Collections.Generic
 open FSharp.CompilerBinding
 open Mono.TextEditor
 open MonoDevelop.Core
 open MonoDevelop.Ide
 open MonoDevelop.SourceEditor
 open MonoDevelop.Ide.CodeCompletion
-open Gdk
-open MonoDevelop.Components
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open MonoDevelop.FSharp.FSharpSymbolHelper
 open ExtCore.Control
-
-type XmlDoc =
-  ///A full xmldoc tooltip
-| Full of string
-  ///A lookup of key, filename
-| Lookup of string * string option
-  ///No xmldoc
-| EmptyDoc
-
-type ToolTips =
-  ///A ToolTip of signature, summary, TextSegment
-| ToolTip of string * XmlDoc * TextSegment
-  ///A empty tip
-| EmptyTip
-
-[<AutoOpen>]
-module Highlight =
-    type HighlightType =
-    | Symbol | Keyword | UserType | Number
-
-    let getColourScheme () =
-        Highlighting.SyntaxModeService.GetColorStyle (IdeApp.Preferences.ColorScheme)
-
-    let hl str (style: Highlighting.ChunkStyle) =
-        let color = getColourScheme().GetForeground (style) |> GtkUtil.ToGdkColor
-        let colorString = HelperMethods.GetColorString (color)
-        sprintf """<span foreground="%s">%s</span>""" colorString str
-
-    let asType t s =
-        let cs = getColourScheme ()
-        match t with
-        | Symbol -> hl s cs.KeywordOperators
-        | Keyword -> hl s cs.KeywordTypes
-        | UserType -> hl s cs.UserTypes
-        | Number -> hl s cs.Number
-
-[<AutoOpen>]
-module NewTooltips =
-
-    let escapeText = GLib.Markup.EscapeText
-
-    /// Concat two strings with a space between if both a and b are not IsNullOrWhiteSpace
-    let (++) (a:string) (b:string) =
-        match String.IsNullOrEmpty a, String.IsNullOrEmpty b with
-        | true, true -> ""
-        | false, true -> a
-        | true, false -> b
-        | false, false -> a + " " + b
-
-    let getSegFromSymbolUse (editor:TextEditor) (symbolUse:FSharpSymbolUse)  =
-        let startOffset = editor.Document.LocationToOffset(symbolUse.RangeAlternate.StartLine, symbolUse.RangeAlternate.StartColumn)
-        let endOffset = editor.Document.LocationToOffset(symbolUse.RangeAlternate.EndLine, symbolUse.RangeAlternate.EndColumn)
-        TextSegment.FromBounds(startOffset, endOffset)
-
-    let getSummaryFromSymbol (symbolUse:FSharpSymbolUse) (backupSig: Lazy<Option<string * string>>) =
-        let xmlDoc, xmlDocSig = 
-            match symbolUse.Symbol with
-            | :? FSharpMemberFunctionOrValue as func -> func.XmlDoc, func.XmlDocSig
-            | :? FSharpEntity as fse -> fse.XmlDoc, fse.XmlDocSig
-            | :? FSharpField as fsf -> fsf.XmlDoc, fsf.XmlDocSig
-            | :? FSharpUnionCase as fsu -> fsu.XmlDoc, fsu.XmlDocSig
-            | :? FSharpActivePatternCase as apc -> apc.XmlDoc, apc.XmlDocSig
-            | :? FSharpGenericParameter as gp -> gp.XmlDoc, ""
-            | _ -> ResizeArray() :> IList<_>, ""
-
-        if xmlDoc.Count > 0 then Full (String.Join( "\n", xmlDoc |> Seq.map escapeText))
-        else
-            if String.IsNullOrWhiteSpace xmlDocSig then
-                let backup = backupSig.Force()
-                match backup with
-                | Some (key, file) ->Lookup (key, Some file)
-                | None -> XmlDoc.EmptyDoc
-            else Lookup(xmlDocSig, symbolUse.Symbol.Assembly.FileName)
-
-    let getUnioncaseSignature displayContext (unionCase:FSharpUnionCase) =
-        if unionCase.UnionCaseFields.Count > 0 then
-           let typeList =
-              unionCase.UnionCaseFields
-              |> Seq.map (fun unionField -> unionField.Name ++ asType Symbol ":" ++ asType UserType (escapeText (unionField.FieldType.Format displayContext)))
-              |> String.concat (asType Symbol " * " )
-           unionCase.Name ++ asType Keyword "of" ++ typeList
-         else unionCase.Name
-
-    let getEntitySignature displayContext (fse: FSharpEntity) =
-        let modifier =
-            match fse.Accessibility with
-            | a when a.IsInternal -> asType Keyword "internal "
-            | a when a.IsPrivate -> asType Keyword "private "
-            | _ -> ""
-
-        let typeName =
-            match fse with
-            | _ when fse.IsFSharpModule -> "module"
-            | _ when fse.IsEnum         -> "enum"
-            | _ when fse.IsValueType    -> "struct"
-            | _                         -> "type"
-
-        let enumtip () =
-            asType Symbol " =" + "\n" + 
-            asType Symbol "|" ++
-            (fse.FSharpFields
-            |> Seq.filter (fun f -> not f.IsCompilerGenerated)
-            |> Seq.map (fun field -> match field.LiteralValue with
-                                     | Some lv -> field.Name + asType Symbol " = " + asType Number (string lv)
-                                     | None -> field.Name )
-            |> String.concat ("\n" + asType Symbol "| " ) )
-
-
-        let uniontip () = 
-            asType Symbol " =" + "\n" + 
-            asType Symbol "|" ++
-            (fse.UnionCases 
-            |> Seq.map (getUnioncaseSignature displayContext)
-            |> String.concat ("\n" + asType Symbol "| " ) )
-                                 
-        let typeDisplay = modifier + asType Keyword typeName ++ asType UserType fse.DisplayName
-        let fullName = "\n\nFull name: " + fse.FullName
-        match fse.IsFSharpUnion, fse.IsEnum with
-        | true, false -> typeDisplay + uniontip () + fullName
-        | false, true -> typeDisplay + enumtip () + fullName
-        | _ -> typeDisplay + fullName
-
-    let getFuncSignature displayContext (func: FSharpMemberFunctionOrValue) =
-        let functionName =
-            if isConstructor func then func.EnclosingEntity.DisplayName
-            else func.DisplayName
-
-        let modifiers =
-            let accessibility =
-                match func.Accessibility with
-                | a when a.IsInternal -> asType Keyword "internal"
-                | a when a.IsPrivate -> asType Keyword "private"
-                | _ -> ""
-
-            let modifier =
-                //F# types are prefixed with new, should non F# types be too for consistancy?
-                if isConstructor func then
-                    if func.EnclosingEntity.IsFSharp then "new" ++ accessibility
-                    else accessibility
-                elif func.IsMember then 
-                    if func.IsInstanceMember then
-                        if func.IsDispatchSlot then "abstract member" ++ accessibility
-                        else "member" ++ accessibility
-                    else "static member" ++ accessibility
-                else
-                    if func.InlineAnnotation = FSharpInlineAnnotation.AlwaysInline then "val" ++ accessibility ++ "inline"
-                    elif func.IsInstanceMember then "val" ++ accessibility
-                    else "val" ++ accessibility //does this need to be static prefixed?
-            modifier
-
-        let argInfos =
-            func.CurriedParameterGroups 
-            |> Seq.map Seq.toList 
-            |> Seq.toList 
-
-        let retType = asType UserType (escapeText(func.ReturnParameter.Type.Format displayContext))
-
-        let padLength = 
-            let allLengths = argInfos |> List.concat |> List.map (fun p -> p.DisplayName.Length)
-            match allLengths with
-            | [] -> 0
-            | l -> l |> List.max
-
-        match argInfos with
-        | [] ->
-            //When does this occur, val type within  module?
-            asType Keyword modifiers ++ functionName ++ asType Symbol ":" ++ retType
-                   
-        | [[]] ->
-            //A ctor with () parameters seems to be a list with an empty list
-            asType Keyword modifiers ++ functionName ++ asType Symbol "() :" ++ retType 
-        | many ->
-                let allParams =
-                    many
-                    |> List.map(fun listOfParams ->
-                                    listOfParams
-                                    |> List.map(fun p -> "   " + p.DisplayName.PadRight (padLength) + asType Symbol ":" ++ asType UserType (escapeText (p.Type.Format displayContext)))
-                                    |> String.concat (asType Symbol " *" ++ "\n"))
-                    |> String.concat (asType Symbol " ->" + "\n") 
-                let typeArguments =
-                    allParams +  "\n   " + (String.replicate (max (padLength-1) 0) " ") +  asType Symbol "->" ++ retType
-                asType Keyword modifiers ++ functionName ++ asType Symbol ":" + "\n" + typeArguments
-
-    let getValSignature displayContext (v:FSharpMemberFunctionOrValue) =
-        let retType = asType UserType (escapeText(v.ReturnParameter.Type.Format displayContext))
-        let prefix = 
-            if v.IsMutable then asType Keyword "val" ++ asType Keyword "mutable"
-            else asType Keyword "val"
-        prefix ++ v.DisplayName ++ asType Symbol ":" ++ retType
-
-    let getFieldSignature displayContext (field: FSharpField) =
-        let retType = asType UserType (escapeText(field.FieldType.Format displayContext))
-        match field.LiteralValue with
-        | Some lv -> field.DisplayName ++ asType Symbol ":" ++ retType ++ asType Symbol "=" ++ asType Number (string lv)
-        | None ->
-            let prefix = 
-                if field.IsMutable then asType Keyword "val" ++ asType Keyword "mutable"
-                else asType Keyword "val"
-            prefix ++ field.DisplayName ++ asType Symbol ":" ++ retType
-
-    let getTooltipFromSymbol (symbolUse:FSharpSymbolUse option) editor (backUpSig: Lazy<_>) =
-        match symbolUse with
-        | Some symbolUse -> 
-            match symbolUse.Symbol with
-            | :? FSharpEntity as fse ->
-                try
-                    let signature = getEntitySignature symbolUse.DisplayContext fse
-                    ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-                with exn -> ToolTips.EmptyTip
-
-            | :? FSharpMemberFunctionOrValue as func ->
-                try
-                if func.CompiledName = ".ctor" then 
-                    if func.EnclosingEntity.IsValueType || func.EnclosingEntity.IsEnum then
-                        //ValueTypes
-                        let signature = getFuncSignature symbolUse.DisplayContext func
-                        ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-                        //ToolTips.EmptyTip
-                    else
-                        //ReferenceType constructor
-                        let signature = getFuncSignature symbolUse.DisplayContext func
-                        ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-                        //ToolTips.EmptyTip
-
-                elif func.FullType.IsFunctionType && not func.IsPropertyGetterMethod && not func.IsPropertySetterMethod && not symbolUse.IsFromComputationExpression then 
-                    if isOperatorOrActivePattern func.DisplayName then
-                        //Active pattern or operator
-                        let signature = getFuncSignature symbolUse.DisplayContext func
-                        ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-                    else
-                        //TODO: Add closure/nested functions
-                        if not func.IsModuleValueOrMember then
-                            //represents a closure or nested function, needs FCS support
-                            ToolTips.EmptyTip
-                        else
-                            let signature = getFuncSignature symbolUse.DisplayContext func
-                            ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)                            
-
-                else
-                    //val name : Type
-                    let signature = getValSignature symbolUse.DisplayContext func
-                    ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-                with exn -> ToolTips.EmptyTip
-
-            | :? FSharpField as fsf ->
-                let signature = getFieldSignature symbolUse.DisplayContext fsf
-                ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-
-            | :? FSharpUnionCase as uc ->
-                let signature = getUnioncaseSignature symbolUse.DisplayContext uc
-                ToolTip(signature, getSummaryFromSymbol symbolUse backUpSig, getSegFromSymbolUse editor symbolUse)
-
-            | :? FSharpActivePatternCase as apc ->
-                //Theres not enough information to build this
-                ToolTips.EmptyTip
-               
-            | _ -> ToolTips.EmptyTip
-
-        | None -> ToolTips.EmptyTip
-
-type TooltipResults =
-| ParseAndCheckNotFound
-| NoToolTipText
-| NoToolTipData
-| Tooltip of TooltipItem
+open SymbolTooltips
 
 /// Resolves locations to tooltip items, and orchestrates their display.
 /// We resolve language items to an NRefactory symbol.
@@ -300,12 +33,9 @@ type FSharpTooltipProvider() =
        lastWindow |> Option.iter (fun w -> w.Destroy())
        enterNotify |> Option.iter (fun en -> en.Dispose ())
 
-
     let isSupported fileName= 
         [|".fs";".fsi";".fsx";".fsscript"|] 
         |> Array.exists ((=) (Path.GetExtension fileName))
-
-
 
     override x.GetItem (editor, offset) =
       try
@@ -322,6 +52,12 @@ type FSharpTooltipProvider() =
         let projFile, files, args, framework = MonoDevelop.getCheckerArgs(extEditor.Project, fileName)
 
         let line, col, lineStr = MonoDevelop.getLineInfoFromOffset(offset, editor.Document)
+
+        let getSegFromRange (doc:TextDocument) (range: Microsoft.FSharp.Compiler.Range.range)  =
+           let startOffset = doc.LocationToOffset(range.StartLine, range.StartColumn)
+           let endOffset = doc.LocationToOffset(range.EndLine, range.EndColumn)
+           TextSegment.FromBounds(startOffset, endOffset)
+
         let result = async {
            let! parseAndCheckResults = MDLanguageService.Instance.GetTypedParseResultWithTimeout (projFile, fileName, docText, files, args, AllowStaleResults.MatchingSource, ServiceSettings.blockingTimeout, framework)
            LoggingService.LogInfo "TooltipProvider: Getting tool tip"
@@ -334,31 +70,37 @@ type FSharpTooltipProvider() =
                // This should be fine as there are issues with genewric tooltip xmldocs anyway
                // e.g. generics such as Dictionary<'a,'b>.Contains currently dont work.
                let! tip = parseAndCheckResults.GetToolTip(line, col, lineStr)
-               //we create the backupSig as lazily as possible we could put the asyn call in here but I was worried about GC retension.
+               //we create the backupSig as lazily as possible we could put the async call in here but I was worried about GC retension.
                let backupSig = 
-                   lazy
-                       match tip with
-                       | Some (ToolTipText xs, (_,_)) when xs.Length > 0 ->
-                           let first = xs.Head    
-                           match first with
-                           | ToolTipElement (name, xmlComment) ->
-                                match xmlComment with
-                                | XmlCommentSignature (key, file) -> Some (file, key)
-                                | _ -> None
-                           | ToolTipElementGroup tts when tts.Length > 0 ->
-                               let name, xmlComment = tts.Head
-                               match xmlComment with
-                               | XmlCommentSignature (key, file) -> Some (file, key)
+                   Some(lazy
+                           match tip with
+                           | Some (ToolTipText xs, (_,_)) when xs.Length > 0 ->
+                               let first = xs.Head    
+                               match first with
+                               | ToolTipElement (name, xmlComment) ->
+                                    match xmlComment with
+                                    | XmlCommentSignature (key, file) -> Some (file, key)
+                                    | _ -> None
+                               | ToolTipElementGroup tts when tts.Length > 0 ->
+                                   let name, xmlComment = tts.Head
+                                   match xmlComment with
+                                   | XmlCommentSignature (key, file) -> Some (file, key)
+                                   | _ -> None
+                               | ToolTipElementCompositionError _ -> None
                                | _ -> None
-                           | ToolTipElementCompositionError _ -> None
-                           | _ -> None
-                       | _ -> None
+                           | _ -> None)
 
-               let typeTip = getTooltipFromSymbol symbol extEditor backupSig
+               let typeTip = 
+                   match symbol with
+                   | Some s -> getTooltipFromSymbolUse s backupSig
+                   | None -> ToolTips.EmptyTip
+
                // As the new tooltips are unfinished we match ToolTip here to use the new tooltips and anything else to run through the old tooltip system
                // In the section above we return EmptyTip for any tooltips symbols that have not yet ben finished
                match typeTip with
-               | ToolTip(signature, summary, textSeg) ->
+               | ToolTip(signature, summary) ->
+                    //get the TextSegment the the symbols range occupies
+                    let textSeg = getSegFromRange extEditor.Document symbol.Value.RangeAlternate
                     //check to see if the last result is the same tooltipitem, if so return the previous tooltipitem
                     match lastResult with
                     | Some(tooltipItem) when


### PR DESCRIPTION
Moved Tooltip code to SymbolHelpers
Refactored to use defined Symbol helper patterns
