### PR TITLE
Fix for fsharp/fsharpbinding#763

### DIFF
--- a/vim/ftplugin/fsharp.vim
+++ b/vim/ftplugin/fsharp.vim
@@ -92,7 +92,7 @@ endif
 let b:shouldParse = 1
 
 function! OnCursorHold ()
-    if b:shouldParse 
+    if exists("b:shouldParse") && b:shouldParse
         call ShowErrors()
         let b:shouldParse = 0
     endif


### PR DESCRIPTION
Added an existence check to the buffer scoped shouldParse variable in OnCursorHold. This prevents the error mentioned in bug report from being displayed.
