### PR TITLE
Fixes for #763 and #762

### DIFF
--- a/vim/ftplugin/fsharp.vim
+++ b/vim/ftplugin/fsharp.vim
@@ -59,6 +59,7 @@ augroup fsharp
     autocmd TextChangedI *.fs[ix]\\\{0,1\} call OnTextChanged()
     autocmd CursorHold   *.fs[ix]\\\{0,1\} call OnCursorHold()
     autocmd BufLeave     *.fs[ix]\\\{0,1\} call OnBufLeave()
+    autocmd BufEnter     *.fs[ix]\\\{0,1\} call OnBufEnter()
 augroup END
 
 com! -buffer -range=% Interactive call s:launchInteractive(<line1>, <line2>)
@@ -108,6 +109,10 @@ function! OnTextChanged()
 endfunction
 
 function! OnInsertLeave()
+endfunction
+
+function! OnBufEnter()
+    call ShowErrors()
 endfunction
 
 function! OnBufLeave()


### PR DESCRIPTION
The first commit tightens up the autocmd patterns to prevent them from firing in .fsproj files,the second one adds bufenter triggers to redo what BufLeave got rid of.
