### PR TITLE
Upgrade ExtCore reference to 0.8.43 in MonoDevelop.FSharpBinding project

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
@@ -508,7 +508,7 @@
       <HintPath>packages\FSharp.Compiler.CodeDom.0.9.1\lib\net40\FSharp.Compiler.CodeDom.dll</HintPath>
     </Reference>
     <Reference Include="ExtCore">
-      <HintPath>packages\ExtCore.0.8.42\lib\net40\ExtCore.dll</HintPath>
+      <HintPath>packages\ExtCore.0.8.43\lib\net40\ExtCore.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/monodevelop/MonoDevelop.FSharpBinding/packages.config
+++ b/monodevelop/MonoDevelop.FSharpBinding/packages.config
@@ -4,5 +4,5 @@
   <package id="FSharp.Compiler.Service" version="0.0.62" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net40" />
   <package id="FSharp.Compiler.CodeDom" version="0.9.1" targetFramework="net40" />
-  <package id="ExtCore" version="0.8.42" targetFramework="net40" />
+  <package id="ExtCore" version="0.8.43" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The new version references FSharp.Core 4.3.0.0, which should fix assembly-resolution issues some Windows users are seeing (previous versions of ExtCore referenced FSharp.Core 4.0.0.0, which isn't as widely available).
