### PR TITLE
MonoDevelop.FSharpBinding.FSharpLanguageBinding.fs Added (r:ProjectReferenceEventArgs) . Avoid  error FS0072

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs
@@ -81,8 +81,8 @@ type FSharpLanguageBinding() =
       IdeApp.Workspace.FileAddedToProject.Subscribe(invalidateAll) |> eventDisposer.Add
       IdeApp.Workspace.FileRemovedFromProject.Subscribe(invalidateAll) |> eventDisposer.Add
       IdeApp.Workspace.FileRenamedInProject.Subscribe(invalidateAll) |> eventDisposer.Add
-      IdeApp.Workspace.ReferenceAddedToProject.Subscribe(fun r -> invalidateProjectFile(r.Project)) |> eventDisposer.Add
-      IdeApp.Workspace.ReferenceRemovedFromProject.Subscribe(fun r -> invalidateProjectFile(r.Project)) |> eventDisposer.Add
+      IdeApp.Workspace.ReferenceAddedToProject.Subscribe(fun (r:ProjectReferenceEventArgs) -> invalidateProjectFile(r.Project)) |> eventDisposer.Add
+      IdeApp.Workspace.ReferenceRemovedFromProject.Subscribe(fun (r:ProjectReferenceEventArgs) -> invalidateProjectFile(r.Project)) |> eventDisposer.Add
       IdeApp.Workspace.SolutionUnloaded.Subscribe(fun _ -> langServ.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()) |> eventDisposer.Add
 
     


### PR DESCRIPTION
Avoiding 
/fsharpbinding/monodevelop/MonoDevelop.FSharpBinding/FSharpLanguageBinding.fs(84,89): error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved. 

on (84,89) and (85,93)
