### PR TITLE
improve build scripts (Windows)

### DIFF
--- a/sublimetext/bin/GetDependencies.ps1
+++ b/sublimetext/bin/GetDependencies.ps1
@@ -10,6 +10,14 @@ function IsVerbose {
     return $VerbosePreference -eq 'Continue'
 }
 
+function unzip {
+    param($Source, $Destination)
+    $shellApp= new-object -com "Shell.Application"
+    $archive = $shellApp.namespace($Source)
+    $dest = $shellApp.namespace($Destination)
+    $dest.copyhere($archive.items())
+}
+
 $script:thisDir = split-path $MyInvocation.MyCommand.Path -parent
 $script:serverDir = resolve-path((join-path $thisDir '../FSharp/fsac/fsac'))
 $script:bundledDir = resolve-path((join-path $thisDir '../FSharp/fsac/fsac'))
@@ -23,13 +31,10 @@ push-location $bundledDir
     $client.DownloadFile('https://bitbucket.org/guillermooo/fsac/downloads/fsac.zip',
                          "$bundledDir\fsac.zip" )
 
-    if (IsVerbose) {
-        & '7z' 'x' 'fsac.zip' '-o.'
-    }
-    else {
-        & '7z' 'x' 'fsac.zip' '-o.' > $null
-    }
-
+    write-verbose 'extracting files...'
+    unzip (get-item 'fsac.zip').fullname (get-location).providerpath
+    write-verbose 'cleaning up...'
     remove-item 'fsac.zip'
 pop-location
+
 write-verbose 'done'


### PR DESCRIPTION
- add -Full parameter to Build.ps1 to also get dependencies
- add progress information
- replace $STDataPath with $STPackagesPath

Usage:

1) Set $STPackagesPath to Sublime Text's packages path

In order to find out your packages path:
   a) Open Sublime Text
   b) Open the Python console
   c) Type in sublime.packages_path()<RETURN>

2) Run once ./bin/Build.ps1 -verbose -full

That should grab dependencies and publish a version locally.

3) Subsequently, you can simply invoke the script like this:

```
./bin/Build.ps1 -verbose
```

In case you'd need to get the dependencies again, just run the
script as in step (3).

Other features of Build.ps1 include:

```
-Restart: restarts Sublime Text (sublime_text must be on your
 PATH)
-Clean: wipes the deployment FSharp target folder
-Debug: stops execution at predefined stages and prints info
```
