### PR TITLE
tooltip fix

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -333,6 +333,7 @@ module SymbolTooltips =
             | _ when fse.IsFSharpModule -> "module"
             | _ when fse.IsEnum         -> "enum"
             | _ when fse.IsValueType    -> "struct"
+            | _ when fse.IsNamespace    -> "namespace"
             | _                         -> "type"
 
         let enumtip () =


### PR DESCRIPTION
Hovering over namespaces displays "type", this fixes it to display "namespace"
