### PR TITLE
Adjust appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  EMACSBIN: emacs-24.4-bin-i686-pc-mingw32.7z
+  EMACSBIN: emacs-24.4-bin-i686-mingw32.7z
 matrix:
   fast_finish: true
 install:


### PR DESCRIPTION
Lookinng at this failure https://ci.appveyor.com/project/fsgit/fsharpbinding/build/1.0.224 it seems emacs is not being downloaded at the start of the AppVeyor build

I couldn't see "emacs-24.4-bin-i686-pc-mingw32.7z" but I could see "emacs-24.4-bin-i686-mingw32.7z" so trying that
