### PR TITLE
Fix to allow AspNet Rajor templates to work correctly

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharpProjectMvc4Razor.windows.xpt.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharpProjectMvc4Razor.windows.xpt.xml
@@ -21,7 +21,7 @@
 			<StartupProject>${ProjectName}</StartupProject>
 		</Options>
 
-		<Project name = "${ProjectName}" directory = "." type = "AspNetMvc3">
+		<Project name = "${ProjectName}" directory = "." type = "AspNetApp">
 			<Options TargetFrameworkVersion = "4.0" />
 			<References>
 				<Reference type="Package" refto="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharpProjectMvc4Razor.xpt.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/FSharpProjectMvc4Razor.xpt.xml
@@ -21,7 +21,7 @@
 			<StartupProject>${ProjectName}</StartupProject>
 		</Options>
 
-		<Project name = "${ProjectName}" directory = "." type = "AspNetMvc3">
+		<Project name = "${ProjectName}" directory = "." type = "AspNetApp">
 			<Options TargetFrameworkVersion = "4.5" />
 			<References>
 				<Reference type="Package" refto="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />


### PR DESCRIPTION
File not found dialog was displayed on creation due to the project type being renamed in the upstream monodevelop repo.

See [#22916](https://bugzilla.xamarin.com/show_bug.cgi?id=22915)
