### PR TITLE
Fix for Vim stacktrace when no completions found

### DIFF
--- a/vim/ftplugin/fsharpvim.py
+++ b/vim/ftplugin/fsharpvim.py
@@ -147,6 +147,10 @@ class FSAutoComplete:
         msg = self.completion.send('completion "%s" %d %d\n' % (fn, line, column))
 
         self.__log('msg received %s\n' % msg)
+
+        if msg is None:
+            return []
+
         msg = map(str, msg)
 
         if base != '':


### PR DESCRIPTION
Fix for issue #894, resolves issue by checking whether the msg from fsautocomplete is None and if so returning an empty list to omnifunc.
