### PR TITLE
Ensure ResolverProvider is wrapped with a total timeout.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpResolverProvider.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpResolverProvider.fs
@@ -59,7 +59,7 @@ type FSharpResolverProvider() =
                 let lastIdent = Symbols.lastIdent col lineStr
                 let resolveResult = NRefactory.createResolveResult(doc.ProjectContent, fsSymbolUse.Symbol, lastIdent, domRegion)
                 return resolveResult, domRegion }
-        match results |> Async.RunSynchronously with
+        match Async.RunSynchronously (results, ServiceSettings.blockingTimeout) with
         | Some (res, dom) ->
             region <- dom
             res


### PR DESCRIPTION
This can potentially block the UI on right click so ensure there’s a
timeout wrapping the whole operation.
