### PR TITLE
Added a FSharpFoldingParser implementation

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml.orig
@@ -167,6 +167,10 @@
     <Parser class="MonoDevelop.FSharp.FSharpParser"  mimeType = "text/x-fsharp" />
   </Extension>
 
+  <Extension path = "/MonoDevelop/TypeSystem/FoldingParser">
+    <Parser class = "MonoDevelop.FSharp.FSharpFoldingParser" mimeType="text/x-fsharp" />
+  </Extension>
+
   <Extension path = "/MonoDevelop/SourceEditor2/TooltipProviders">
     <Class id="LanguageItem" class="MonoDevelop.FSharp.FSharpTooltipProvider" mimeType="text/x-fsharp" />
   </Extension>

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpFoldingParser.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpFoldingParser.fs
@@ -1,0 +1,11 @@
+﻿namespace MonoDevelop.FSharp
+open System
+open MonoDevelop.Ide.TypeSystem
+
+/// The folding parser is used for generating a preliminary parsed document that does not
+/// contain a full dom - only some basic lexical constructs such as comments or pre processor directives.
+/// As we dont currently fold comments or compiler directives this is an empty DefaultParsedDocument
+type FSharpFoldingParser() =
+    interface IFoldingParser with
+        member x.Parse(fileName, _content) = 
+            DefaultParsedDocument (fileName) :> _

--- a/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
+++ b/monodevelop/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj.orig
@@ -96,6 +96,7 @@
     <Compile Include="FSharpOptionsPanels.fs" />
     <Compile Include="FSharpLanguageBinding.fs" />
     <Compile Include="FSharpResourceIdBuilder.fs" />
+    <Compile Include="FSharpFoldingParser.fs" />
     <Compile Include="FSharpParser.fs" />
     <Compile Include="FSharpTextEditorCompletion.fs" />
     <Compile Include="FSharpPathExtension.fs" />


### PR DESCRIPTION
The initial load of an F# document causes either an
IFoldingParser.Parse or a FSharpParser.Parse to be invoked.
FSharpParser.Parse uses the language service to make a blocking call to
retrieve the ParseAndCheckResults which
is usually no issue as this is on a background thread, however, during
load this is carried out on the UI thread.

Adding the default implementation of an IFoldingParser means that we
can return control to the UI quickly and still
have the async parse continue in the background which will update the
UI when completed.