### PR TITLE
Modify tooltip code to be less blocking on the UI thread

### DIFF
--- a/FSharp.CompilerBinding/LanguageService.fs
+++ b/FSharp.CompilerBinding/LanguageService.fs
@@ -401,6 +401,12 @@ type LanguageService(dirtyNotify) =
     | None -> return! mbox.PostAndAsyncReply(fun reply -> (fileName, src, opts, reply))
    }
 
+  member x.GetTypedParseResultIfAvailable(projectFilename, fileName:string, src, files, args, stale) = 
+    let opts = x.GetCheckerOptions(fileName, projectFilename, src, files, args)
+    match x.TryGetStaleTypedParseResult(fileName, opts, src, stale)  with
+    | Some results -> results
+    | None -> ParseAndCheckResults.Empty
+
 
   /// Get all the uses of a symbol in the given file (using 'source' as the source for the file)
   member x.GetUsesOfSymbolAtLocationInFile(projectFilename, fileName, source, files, line:int, col, lineStr, args) =

--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -216,7 +216,7 @@ module SymbolTooltips =
         | true, false -> b
         | false, false -> a + " " + b
 
-    let getSummaryFromSymbol (symbol:FSharpSymbol) (backupSig: Lazy<Option<string * string>> option) =
+    let getSummaryFromSymbol (symbol:FSharpSymbol) (backupSig: Lazy<Option<string * string>>) =
         let xmlDoc, xmlDocSig = 
             match symbol with
             | :? FSharpMemberOrFunctionOrValue as func -> func.XmlDoc, func.XmlDocSig
@@ -230,11 +230,8 @@ module SymbolTooltips =
         if xmlDoc.Count > 0 then Full (String.Join( "\n", xmlDoc |> Seq.map escapeText))
         else
             if String.IsNullOrWhiteSpace xmlDocSig then
-                match backupSig with
-                | Some backup ->
-                     match backup.Force() with
-                     | Some (key, file) ->Lookup (key, Some file)
-                     | None -> XmlDoc.EmptyDoc
+                match backupSig.Force() with
+                | Some (key, file) -> Lookup (key, Some file)
                 | None -> XmlDoc.EmptyDoc
             else Lookup(xmlDocSig, symbol.Assembly.FileName)
 
@@ -376,7 +373,7 @@ module SymbolTooltips =
                 else asType Keyword "val"
             prefix ++ field.DisplayName ++ asType Symbol ":" ++ retType
 
-    let getTooltipFromSymbolUse (symbol:FSharpSymbolUse) (backUpSig: Lazy<_> option) =
+    let getTooltipFromSymbolUse (symbol:FSharpSymbolUse) (backUpSig: Lazy<_>) =
         match symbol with
         | Entity fse ->
             try


### PR DESCRIPTION
During profiling there were regularly signs of blocking greater than
the blocking timeout so switching the code to use stale results should
bypass a few async calls that were unnecessary.