### PR TITLE
Remove minimum version form the unified iOS templates

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_Universal.Storyboard.plist.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_Universal.Storyboard.plist.xml
@@ -24,7 +24,5 @@
 	<string>MainStoryboard_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>
 	<string>MainStoryboard_iPad</string>
-	<key>MinimumOSVersion</key>
-	<string>5.0</string>
 </dict>
 </plist>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_Universal.plist.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_Universal.plist.xml
@@ -20,7 +20,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>MinimumOSVersion</key>
-	<string>3.2</string>
 </dict>
 </plist>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_iPad.Storyboard.plist.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_iPad.Storyboard.plist.xml
@@ -15,7 +15,5 @@
 	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
-	<key>MinimumOSVersion</key>
-	<string>5.0</string>
 </dict>
 </plist>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_iPad.plist.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_iPad.plist.xml
@@ -13,7 +13,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>MinimumOSVersion</key>
-	<string>3.2</string>
 </dict>
 </plist>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_iPhone.Storyboard.plist.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/Xamarin.iOS/Project/Common/Info_iPhone.Storyboard.plist.xml
@@ -10,7 +10,5 @@
 	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
-	<key>MinimumOSVersion</key>
-	<string>5.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
Previously the minimum version was set to 3.2 or 5.0 which was lower
than the minimum for unified apps (5.1.1)