### PR TITLE
Place cursor in roughly the same location after formatting document (Ctrl-I)

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/FSharpFormatter.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/FSharpFormatter.fs
@@ -86,7 +86,11 @@ type FSharpFormatter()  =
                     let result =
                         trimIfNeeded input (CodeFormatter.formatSourceString isFsiFile input config)
                     //If onTheFly do the replacements in the document
-                    doc |> Option.iter (fun d -> d.Editor.Document.Replace(0, input.Length, result))
+                    doc |> Option.iter (fun d -> 
+                        let line = d.Editor.Caret.Line
+                        let col = d.Editor.Caret.Column
+                        d.Editor.Document.Replace(0, input.Length, result)
+                        d.Editor.SetCaretTo (line, col, false))
                     result
                 with exn -> 
                     LoggingService.LogError("Error occured: {0}", exn.Message)


### PR DESCRIPTION

Due to reformatting, cursor may not end up on the same line of code, but this improves the situation at least
Fixes #829