### PR TITLE
Syntax highlighting: Improve multiline comments

### DIFF
--- a/sublimetext/FSharp/FSharp.tmLanguage
+++ b/sublimetext/FSharp/FSharp.tmLanguage
@@ -246,7 +246,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>//.*$</string>
+					<string>\/\/(?:(?!\*\)).)*$</string>
 					<key>name</key>
 					<string>comment.line.double-slash.fsharp</string>
 				</dict>

--- a/sublimetext/FSharp/FSharp.tmLanguage
+++ b/sublimetext/FSharp/FSharp.tmLanguage
@@ -432,7 +432,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(try|finally|new|in|as|if|then|else|elif|raise|for|begin|end|match|with|when|type|inherit|null|do)\b</string>
+					<string>\b(try|finally|new|in|as|if|then|else|elif|raise|for|begin|end|match|with|when|type|inherit|null|do|while)\b</string>
 					<key>name</key>
 					<string>keyword.other.fsharp</string>
 				</dict>


### PR DESCRIPTION
Fixes #953.

It seems that when `// something *)` is found, that excludes the `*)` from being processed by multiline regexes.
The solution here is to match single line comments *until* but excluding `*)`.
This means `*)` is still available to the highlighter, but it also means that if you write `// comment *)` without having a starting `(*`, everything after and including the `*)` will not get highlighted correctly. I can live with that. 
