### PR TITLE
Xamarin.Mac project template categories

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Files/WindowWithController/Window.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Files/WindowWithController/Window.fs
@@ -11,8 +11,8 @@ type ${Name} =
     new () = { inherit NSWindow () }
     new (handle : IntPtr) = { inherit NSWindow (handle) }
 
-	[<Export ("initWithCoder:")>]
-	new (coder : NSCoder) = { inherit NSWindow (coder) }
+    [<Export ("initWithCoder:")>]
+    new (coder : NSCoder) = { inherit NSWindow (coder) }
 
-	override x.AwakeFromNib () =
-		base.AwakeFromNib ()
+    override x.AwakeFromNib () =
+        base.AwakeFromNib ()

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Files/WindowWithController/WindowController.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Files/WindowWithController/WindowController.fs
@@ -10,11 +10,11 @@ type ${Name}Controller =
 
     new () = { inherit NSWindowController ("${Name}") }
     new (handle : IntPtr) = { inherit NSWindowController (handle) }
-	
-	[<Export ("initWithCoder:")>]
-	new (coder : NSCoder) = { inherit NSWindowController (coder) }
 
-	override x.AwakeFromNib () =
-		base.AwakeFromNib ()
+    [<Export ("initWithCoder:")>]
+    new (coder : NSCoder) = { inherit NSWindowController (coder) }
 
-	member x.Window with get () = base.Window :?> ${Name}
+    override x.AwakeFromNib () =
+        base.AwakeFromNib ()
+
+    member x.Window with get () = base.Window :?> ${Name}

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/Application.xpt.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/Application.xpt.xml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0"?>
 <Template>
 	<TemplateConfiguration>
-		<_Name>Xamarin.Mac Application</_Name>
-		<_Category>F#/Mac/Unified API</_Category>
+		<_Name>Cocoa App</_Name>
+		<Category>mac/app/general</Category>
+		<Icon>md-project-mac</Icon>
+		<Image id="md-mac-application" />
 		<LanguageName>F#</LanguageName>
-		<_Description><![CDATA[*** PREVIEW ONLY ***
+		<GroupId>md-xamarin-mac-unified-project</GroupId>
+		<_Description><![CDATA[A basic Cocoa Mac App with XIB support that targets the new Unified API shared with Xamarin.iOS. Requires Xcode 5 or newer.
 
-A basic Cocoa Mac application that targets the new Unified API shared with Xamarin.iOS. Requires Xcode 5 or newer.
+The Unified API supports both 32 and 64-bit platforms, unlike the Classic API which supports only 32-bit platforms. 
 
-The Unified API supports both 32 and 64-bit platforms, unlike the Classic API which supports only 32-bit platforms. The Unified API also removes namespace prefixes to allow better code sharing between Xamarin.Mac and Xamarin.iOS projects.
-
-Currently the Unified API is available as a preview, is subject to change, and stability is not yet guaranteed.]]>
-		</_Description>
+The Unified API also removes namespace prefixes to allow better code sharing between Xamarin.Mac and Xamarin.iOS projects.]]></_Description>
 	</TemplateConfiguration>
 
 	<Actions>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/Application/Main.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/Application/Main.fs
@@ -5,6 +5,6 @@ open AppKit
 module main =
     [<EntryPoint>]
     let main args =
-		NSApplication.Init ()
-		NSApplication.Main (args)
-		0
+        NSApplication.Init ()
+        NSApplication.Main (args)
+        0

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/EmptyApplication.xpt.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/EmptyApplication.xpt.xml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0"?>
 <Template>
 	<TemplateConfiguration>
-		<_Name>Xamarin.Mac Empty Application</_Name>
-		<_Category>F#/Mac/Unified API</_Category>
+		<_Name>Empty Project</_Name>
+		<Category>mac/app/general</Category>
+		<Icon>md-project-mac</Icon>
+		<Image id="md-mac-application" />
 		<LanguageName>F#</LanguageName>
-		<_Description><![CDATA[*** PREVIEW ONLY ***
+		<GroupId>md-xamarin-mac-unified-empty-project</GroupId>
+		<_Description><![CDATA[An empty Mac project that targets the new Unified API shared with Xamarin.iOS. Requires Xcode 5 or newer.
 
-An empty Cocoa Mac application that targets the new Unified API shared with Xamarin.iOS. Requires Xcode 5 or newer.
+The Unified API supports both 32 and 64-bit platforms, unlike the Classic API which supports only 32-bit platforms. 
 
-The Unified API supports both 32 and 64-bit platforms, unlike the Classic API which supports only 32-bit platforms. The Unified API also removes namespace prefixes to allow better code sharing between Xamarin.Mac and Xamarin.iOS projects.
-
-Currently the Unified API is available as a preview, is subject to change, and stability is not yet guaranteed.]]>
-		</_Description>
+The Unified API also removes namespace prefixes to allow better code sharing between Xamarin.Mac and Xamarin.iOS projects.]]></_Description>
 	</TemplateConfiguration>
 
 	<Actions>

--- a/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/Library.xpt.xml
+++ b/monodevelop/MonoDevelop.FSharpBinding/Templates/MonoMac/XamMacUnified/Projects/Library.xpt.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0"?>
 <Template>
 	<TemplateConfiguration>
-		<_Name>Xamarin.Mac Library Project</_Name>
-		<_Category>F#/Mac/Unified API</_Category>
+		<_Name>Library Project</_Name>
+		<Category>mac/library/unified</Category>
 		<Icon>md-project-library</Icon>
+		<Image id="md-library-project" />
 		<LanguageName>F#</LanguageName>
-		<_Description><![CDATA[*** PREVIEW ONLY ***
+		<GroupId>md-xamarin-mac-unified-library-project</GroupId>
+		<_Description><![CDATA[A basic Cocoa Mac library project with XIB support that targets the new Unified API shared with Xamarin.iOS. Requires Xcode 5 or newer.
 
-			A basic Cocoa Mac library that targets the new Unified API shared with Xamarin.iOS. Requires Xcode 5 or newer.
+The Unified API supports both 32 and 64-bit platforms, unlike the Classic API which supports only 32-bit platforms. 
 
-			The Unified API supports both 32 and 64-bit platforms, unlike the Classic API which supports only 32-bit platforms. The Unified API also removes namespace prefixes to allow better code sharing between Xamarin.Mac and Xamarin.iOS projects.
-
-			Currently the Unified API is available as a preview, is subject to change, and stability is not yet guaranteed.]]>
-		</_Description>
+The Unified API also removes namespace prefixes to allow better code sharing between Xamarin.Mac and Xamarin.iOS projects.]]></_Description>
 	</TemplateConfiguration>
 	
 	<Actions>


### PR DESCRIPTION
The Xamarin.Mac project templates are now displayed in the correct categories in Xamarin Studio's New Project dialog.

Also replaced the tabs in some of the project template files which was causing compilation errors.

Currently the empty project and the application project template compile but do not run with the latest Xamarin.Mac. When run the logs shows that mono is unable to find the custom attr constructor image and then you get a SIGABRT.