### PR TITLE
Add target fsautocomplete into Vim plugin Makefile

### DIFF
--- a/vim/Makefile
+++ b/vim/Makefile
@@ -17,6 +17,8 @@ dest_bin  = $(dest_root)/ftplugin/bin/
 
 # Building
 
+fsautocomplete : $(ac_exe)
+
 $(ac_exe) : $(bin_d) ~/.config/.mono/certs
 	xbuild $(ac_fsproj) /property:OutputPath="$(bin_d)"
 
@@ -50,3 +52,5 @@ $(bin_d)     :; mkdir -p $(bin_d)
 
 clean :
 	rm -rf $(bin_d)
+
+.PHONY: fsautocomplete


### PR DESCRIPTION
fsautocomplete is a fixed path-independent pseudonym for target which makes
fsautocomplete.exe. It might be useful when Vim plugin is installed (and
built) by one of Vim plugin managers (NeoBundle, vim-plug etc.).

With [vim-plug](https://github.com/junegunn/vim-plug) it could be used like:
```vim
Plug 'fsharp/fsharpbinding', {'for': 'fsharp', 'rtp': 'vim', 'do': 'make -C vim fsautocomplete'}
```
With [NeoBundle](https://github.com/Shougo/neobundle.vim) it could be used like:
```vim
NeoBundle 'fsharp/fsharpbinding', {
           \ 'description': 'F# support for Vim',
           \ 'rtp': 'vim',
           \ 'lazy': 1,
           \ 'autoload': {'filetypes': 'fsharp'},
           \ 'build': {'others': 'make -C vim fsautocomplete'},
           \ 'build_commands': ['make', 'mozroots', 'xbuild'],
           \}
```