### PR TITLE
Make default-directory of fsi process configurable

### DIFF
--- a/emacs/inf-fsharp-mode.el
+++ b/emacs/inf-fsharp-mode.el
@@ -50,6 +50,9 @@
     (concat "\"" (executable-find "fsi.exe") "\"")))
   "*Program name for invoking an inferior fsharp from Emacs.")
 
+(defvar inferior-fsharp-directory "."
+  "The default-directory of the `inferior-fsharp-program'.")
+
 ;; End of User modifiable variables
 
 
@@ -120,7 +123,8 @@ be sent from another buffer in fsharp mode.
                                           inferior-fsharp-program))))
     (setq inferior-fsharp-program cmd)
     (let ((cmdlist (inferior-fsharp-args-to-list cmd))
-          (process-connection-type nil))
+          (process-connection-type nil)
+          (default-directory inferior-fsharp-directory))
       (set-buffer (apply (function make-comint)
                          inferior-fsharp-buffer-subname
                          (car cmdlist) nil (cdr cmdlist)))


### PR DESCRIPTION
This allows the user to specify the working directory of the fsi process being lunched by fsharp-show-subshell.