### PR TITLE
Push the mark before going to definition

### DIFF
--- a/emacs/fsharp-mode-completion.el
+++ b/emacs/fsharp-mode-completion.el
@@ -460,6 +460,7 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
   (interactive)
   (when (fsharp-ac-can-make-request)
     (fsharp-ac-parse-current-buffer)
+    (push-mark)
     (fsharp-ac-send-pos-request "finddecl"
                                 (fsharp-ac--buffer-truename)
                                 (line-number-at-pos)


### PR DESCRIPTION
Going to definition is usually a "bigger" jump - which makes it feasable
to push the mark. This allows to go back after looking up a definition
of a symbol.