### PR TITLE
Fix vim build

### DIFF
--- a/FSharp.CompilerBinding/FSharp.CompilerBinding.fsproj
+++ b/FSharp.CompilerBinding/FSharp.CompilerBinding.fsproj
@@ -11,7 +11,7 @@
     <UsePartialTypes>False</UsePartialTypes>
     <AssemblyName>FSharp.CompilerBinding</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\monodevelop\MonoDevelop.FSharpBinding\</SolutionDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\FSharp.AutoComplete\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>


### PR DESCRIPTION
SolutionDir pointed to a non-existing monodevelop dir previously and
resolution of FSharp.Compiler.Service failed as a result.

`make -C vim fsautocomplete` runs now successfully