### PR TITLE
Fix compilation error when using F# 4.0 compiler.

### DIFF
--- a/monodevelop/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -131,7 +131,7 @@ module CompilerArguments =
         for file in projectReferences do 
           yield "-r:" + wrapf(file) ]
 
-  let getCurrentConfigurationOrDefault (proj:Project) =
+  let getCurrentConfigurationOrDefault (_: Project) =
      match IdeApp.Workspace with
      | ws when ws <> null && ws.ActiveConfiguration <> null -> ws.ActiveConfiguration
      | _ -> ConfigurationSelector.Default

--- a/monodevelop/MonoDevelop.FSharpBinding/Services/NRefactory.fs
+++ b/monodevelop/MonoDevelop.FSharpBinding/Services/NRefactory.fs
@@ -34,7 +34,7 @@ module NRefactory =
             member x.LastIdent = lastIdent
 
     /// An NRefactory symbol for an F# method, property or other member definition.
-    type FSharpResolvedMethod(unresolvedMember, context, symbol, lastIdent) = 
+    type FSharpResolvedMethod(unresolvedMember: DefaultUnresolvedMethod, context, symbol, lastIdent) = 
         inherit DefaultResolvedMethod(unresolvedMember, context)
         interface IHasFSharpSymbol with 
             member x.FSharpSymbol = symbol


### PR DESCRIPTION
Compilation error when using F# 4.0 compiler on Mono platform:

`/home/janno/Work/fsharpbinding/monodevelop/MonoDevelop.FSharpBinding/Services/NRefactory.fs(10,10): Error FS0966: The type 'FSharpUnresolvedMethod' is used in an invalid way. A value prior to 'FSharpUnresolvedMethod' has an inferred type involving 'FSharpUnresolvedMethod', which is an invalid forward reference. (FS0966) (MonoDevelop.FSharp.mac-linux)`

Fixed it by adding a type annotation to FSharpResolvedMethod default constructor.